### PR TITLE
fix: strip stale thinking blocks when loading messages from DB

### DIFF
--- a/src/agentlys/chat.py
+++ b/src/agentlys/chat.py
@@ -242,9 +242,18 @@ class Agentlys(AgentlysBase):
                 latest_compaction_idx = i
 
         if latest_compaction_idx is not None:
-            self.messages = messages[latest_compaction_idx:]
-        else:
-            self.messages = messages
+            messages = messages[latest_compaction_idx:]
+
+        # Strip thinking blocks from loaded messages — they may have stale
+        # signatures from an older model version or be modified by DB
+        # serialization.  The Anthropic docs confirm omitting thinking from
+        # prior turns is safe.  Live tool-loop thinking is never loaded
+        # through this path (it's appended via self.messages.append).
+        for msg in messages:
+            if msg.role == "assistant":
+                msg.parts = [p for p in msg.parts if p.type != "thinking"]
+
+        self.messages = messages
 
     def add_function(
         self,


### PR DESCRIPTION
## Summary

- Strip thinking blocks from assistant messages in `load_messages()` — the DB→memory boundary
- Fixes Anthropic API 400 errors: "thinking or redacted_thinking blocks in the latest assistant message cannot be modified"
- Affects regeneration and session resume for long-running conversations

## Root cause

When conversations are loaded from DB, `_strip_thinking_from_prior_turns()` can incorrectly preserve stale thinking blocks on the last assistant message when followed by a `tool_result`. The thinking signatures may be from an older model version or subtly modified by DB serialization → Anthropic rejects with 400.

**Bug path:**
1. DB-loaded messages end with `assistant[thinking+tool_use(T)]`
2. `add_empty_function_result()` inserts empty `tool_result(T)` after the orphaned `tool_use`
3. `merge_messages()` merges this into the next user message
4. `_strip_thinking_from_prior_turns()` sees last assistant followed by `tool_result` → preserves stale thinking
5. Anthropic API rejects → 400

## Fix

Strip thinking blocks at `load_messages()` time. Per [Anthropic docs](https://platform.claude.com/docs/en/docs/build-with-claude/extended-thinking): "you can omit thinking blocks from prior assistant role turns."

Live tool-loop thinking (appended via `self.messages.append()` during `ask_stream_async`) is unaffected — it never passes through `load_messages()`, so reasoning continuity during active tool loops is preserved.

## Test plan

- [x] All agentlys tests pass (compaction, thinking, anthropic)
- [x] All myriade-private service tests pass (217 passed)
- [ ] Deploy to Jules instance and verify 400 errors stop in BetterStack logs


🤖 Generated with [Claude Code](https://claude.com/claude-code)