### PR TITLE
fix: skip empty messages during compaction after thinking block removal

### DIFF
--- a/src/agentlys/chat.py
+++ b/src/agentlys/chat.py
@@ -255,6 +255,10 @@ class Agentlys(AgentlysBase):
             if msg.role == "assistant":
                 msg.parts = [p for p in msg.parts if p.type != "thinking"]
 
+        # Remove messages that became empty after thinking block removal
+        # (e.g. assistant messages that contained only thinking parts)
+        messages = [m for m in messages if m.parts]
+
         self.messages = messages
 
     def add_function(

--- a/src/agentlys/compaction.py
+++ b/src/agentlys/compaction.py
@@ -85,8 +85,11 @@ class TokenThresholdCompaction:
             return
 
         # Summarize the entire conversation into a single compaction message.
+        # Skip messages with no parts (e.g. after thinking block removal).
         conversation_text = []
         for msg in messages:
+            if not msg.parts:
+                continue
             conversation_text.append(msg.to_markdown())
         conversation_str = "\n".join(conversation_text)
 

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -308,6 +308,37 @@ class TestTokenThresholdCompactionCompact(unittest.TestCase):
 
         self.assertEqual(len(agent.messages), 0)
 
+    def test_compact_skips_empty_messages(self):
+        """Compaction should not crash on messages with no parts (e.g. after thinking removal)."""
+        compaction = TokenThresholdCompaction()
+        agent = Agentlys(
+            instruction="Test", provider=APIProvider.ANTHROPIC, compaction=compaction
+        )
+        agent.messages = [
+            Message(role="user", content="Hello"),
+            Message(role="assistant", parts=[]),  # empty after thinking removal
+            Message(role="user", content="Follow up"),
+            Message(role="assistant", content="Response"),
+        ]
+
+        mock_text_block = MagicMock()
+        mock_text_block.type = "text"
+        mock_text_block.text = "<summary>Summary</summary>"
+        mock_response = MagicMock()
+        mock_response.content = [mock_text_block]
+
+        agent.provider.client = MagicMock()
+        agent.provider.client.messages.create = AsyncMock(return_value=mock_response)
+
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(compaction.compact(agent))
+        finally:
+            loop.close()
+
+        self.assertEqual(len(agent.messages), 1)
+        self.assertTrue(agent.messages[0].has_compaction)
+
     def test_compact_extracts_summary_without_tags(self):
         """When the model doesn't use summary tags, use the full response."""
         compaction = TokenThresholdCompaction()


### PR DESCRIPTION
## Summary
- When assistant messages contain only thinking blocks, `load_messages()` strips them leaving `parts = []`
- Compaction then crashes calling `to_markdown()` on these empty messages (`ValueError: Message should have at least one part`)
- **Root cause fix** (`chat.py`): Filter out messages that became empty after thinking block removal
- **Defense-in-depth** (`compaction.py`): Skip empty messages instead of crashing

## Context
- 4 occurrences on myriade-jules at 2026-04-01 14:15-14:17 UTC
- All via `regenerate_stream_async` → compaction path
- Linear: DEV-1150

## Test plan
- [x] Added `test_compact_skips_empty_messages` — verifies compaction succeeds when messages have empty parts
- [x] All 28 compaction tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)