### PR TITLE
Prevent compaction during tool use/result exchanges

### DIFF
--- a/src/agentlys/chat.py
+++ b/src/agentlys/chat.py
@@ -172,6 +172,55 @@ class Agentlys(AgentlysBase):
         if self.cancel_event is not None and self.cancel_event.is_set():
             raise StopLoopException("Cancelled via cancel_event")
 
+    def _is_tool_result_message(
+        self, message: typing.Optional[Message]
+    ) -> bool:
+        """True if the message carries tool/function results.
+
+        Compaction must not run when the next message is a tool result, because
+        wiping history would orphan the corresponding tool_use block in the
+        prior assistant message and the API would reject the request.
+        """
+        if message is None:
+            return False
+        if message.role in ("function", "tool"):
+            return True
+        return any(
+            part.type in ("function_result", "function_result_image")
+            for part in (message.parts or [])
+        )
+
+    def _has_unanswered_tool_use(self) -> bool:
+        """True if the last message is an assistant turn with pending tool_use.
+
+        Compacting in this state would drop the tool_use blocks while a future
+        tool_result still references their ids — the same orphan condition as
+        above, just observed from the other side.
+        """
+        if not self.messages:
+            return False
+        last = self.messages[-1]
+        if last.role != "assistant":
+            return False
+        return any(
+            part.type == "function_call" for part in (last.parts or [])
+        )
+
+    async def _maybe_compact(
+        self, next_message: typing.Optional[Message]
+    ) -> bool:
+        """Run compaction if safe. Returns True if compaction executed."""
+        if not (self.compaction and hasattr(self.compaction, "should_compact")):
+            return False
+        if self._is_tool_result_message(next_message):
+            return False
+        if self._has_unanswered_tool_use():
+            return False
+        if not await self.compaction.should_compact(self):
+            return False
+        await self.compaction.compact(self)
+        return True
+
     @classmethod
     def from_template(cls, chat_template: str, **kwargs):
         instruction, examples = parse_chat_template(chat_template)
@@ -643,9 +692,8 @@ class Agentlys(AgentlysBase):
 
         # Run compaction before appending the new message so it is never
         # included in the summary — the LLM must see the exact user request.
-        if self.compaction and hasattr(self.compaction, "should_compact"):
-            if await self.compaction.should_compact(self):
-                await self.compaction.compact(self)
+        # Skipped mid tool exchange to avoid orphaning tool_use/tool_result.
+        await self._maybe_compact(message)
 
         if message:
             self.messages.append(message)
@@ -1065,15 +1113,21 @@ class Agentlys(AgentlysBase):
 
         # Run compaction before appending the new message so it is never
         # included in the summary — the LLM must see the exact user request.
-        if self.compaction and hasattr(self.compaction, "should_compact"):
-            if await self.compaction.should_compact(self):
-                yield {"type": "compacting"}
-                await self.compaction.compact(self)
-                # Yield the compaction summary message so callers can persist it.
-                # Only emit when compact() actually produced a summary (it can
-                # be a no-op when there are too few messages to compact).
-                if self.messages[0].has_compaction:
-                    yield {"type": "compaction_message", "message": self.messages[0]}
+        # Skipped mid tool exchange to avoid orphaning tool_use/tool_result.
+        if (
+            self.compaction
+            and hasattr(self.compaction, "should_compact")
+            and not self._is_tool_result_message(message)
+            and not self._has_unanswered_tool_use()
+            and await self.compaction.should_compact(self)
+        ):
+            yield {"type": "compacting"}
+            await self.compaction.compact(self)
+            # Yield the compaction summary message so callers can persist it.
+            # Only emit when compact() actually produced a summary (it can
+            # be a no-op when there are too few messages to compact).
+            if self.messages[0].has_compaction:
+                yield {"type": "compaction_message", "message": self.messages[0]}
 
         if message:
             self.messages.append(message)

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -519,6 +519,121 @@ class TestCompactionIntegrationWithAskAsync(unittest.TestCase):
         self.assertEqual(result.usage["input_tokens"], 42000)
 
 
+class TestCompactionMidToolExchange(unittest.TestCase):
+    """Compaction must not run mid tool_use/tool_result exchange.
+
+    Wiping history while the next message is a tool_result, or while the
+    last message ends with an unanswered tool_use, would orphan the
+    tool_use_id and the API would reject the next request with:
+    "tool_result block must have a corresponding tool_use block".
+    """
+
+    def _make_agent(self):
+        mock_compaction = MagicMock()
+        mock_compaction.should_compact = AsyncMock(return_value=True)
+        mock_compaction.compact = AsyncMock()
+        agent = Agentlys(
+            instruction="Test",
+            provider=APIProvider.ANTHROPIC,
+            compaction=mock_compaction,
+        )
+        agent.provider.client = MagicMock()
+        return agent, mock_compaction
+
+    def _fake_response(self):
+        class FakeResponse:
+            def to_dict(self):
+                return {
+                    "role": "assistant",
+                    "content": "Hi",
+                    "usage": {"input_tokens": 100, "output_tokens": 10},
+                }
+
+        return FakeResponse()
+
+    def test_skips_compaction_when_next_message_is_function_result(self):
+        agent, mock_compaction = self._make_agent()
+        agent.messages = [
+            Message(role="user", content="Hi"),
+            Message(
+                role="assistant",
+                parts=[
+                    MessagePart(
+                        type="function_call",
+                        function_call={"name": "f", "arguments": "{}"},
+                        function_call_id="toolu_1",
+                    )
+                ],
+            ),
+        ]
+        tool_result = Message(
+            role="function",
+            parts=[
+                MessagePart(
+                    type="function_result",
+                    content="result",
+                    function_call_id="toolu_1",
+                )
+            ],
+        )
+
+        mock_create = AsyncMock(return_value=self._fake_response())
+        with patch.object(agent.provider.client.messages, "create", mock_create):
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(agent.ask_async(tool_result))
+            finally:
+                loop.close()
+
+        mock_compaction.compact.assert_not_called()
+        # Tool result was still appended; assistant tool_use is preserved.
+        self.assertEqual(agent.messages[1].parts[0].function_call_id, "toolu_1")
+        self.assertIn(tool_result, agent.messages)
+
+    def test_skips_compaction_when_last_message_has_pending_tool_use(self):
+        agent, mock_compaction = self._make_agent()
+        agent.messages = [
+            Message(role="user", content="Hi"),
+            Message(
+                role="assistant",
+                parts=[
+                    MessagePart(
+                        type="function_call",
+                        function_call={"name": "f", "arguments": "{}"},
+                        function_call_id="toolu_1",
+                    )
+                ],
+            ),
+        ]
+
+        mock_create = AsyncMock(return_value=self._fake_response())
+        with patch.object(agent.provider.client.messages, "create", mock_create):
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(agent.ask_async())
+            finally:
+                loop.close()
+
+        mock_compaction.compact.assert_not_called()
+
+    def test_compaction_runs_for_normal_user_message(self):
+        agent, mock_compaction = self._make_agent()
+        agent.messages = [
+            Message(role="user", content="Hi"),
+            Message(role="assistant", content="Hello"),
+        ]
+
+        mock_create = AsyncMock(return_value=self._fake_response())
+        with patch.object(agent.provider.client.messages, "create", mock_create):
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(agent.ask_async("Follow-up"))
+            finally:
+                loop.close()
+
+        mock_compaction.compact.assert_called_once_with(agent)
+
+
 class TestCustomCompactionHandler(unittest.TestCase):
     """Tests for using a custom CompactionHandler."""
 


### PR DESCRIPTION
## Summary
Prevent message compaction from running while a tool use/result exchange is in progress. Compacting mid-exchange would orphan tool_use IDs, causing the API to reject subsequent requests with "tool_result block must have a corresponding tool_use block" errors.

## Key Changes
- Added `_is_tool_result_message()` helper to detect when the next message is a tool result
- Added `_has_unanswered_tool_use()` helper to detect when the last message contains pending tool_use blocks
- Introduced `_maybe_compact()` method that safely runs compaction only when neither condition is true
- Updated `ask_async()` to use the new `_maybe_compact()` method
- Updated `ask_stream_async()` to check both conditions before running compaction
- Added comprehensive test suite (`TestCompactionMidToolExchange`) with three test cases:
  - Skips compaction when next message is a function result
  - Skips compaction when last message has pending tool_use
  - Allows compaction for normal user messages

## Implementation Details
The fix ensures compaction is skipped in two critical scenarios:
1. **Incoming tool result**: When `ask_async()` is called with a tool_result message, compaction is skipped to preserve the corresponding tool_use block in the prior assistant message
2. **Pending tool use**: When the last assistant message contains unanswered tool_use blocks, compaction is skipped to prevent orphaning those blocks before the tool_result arrives

This maintains the invariant that tool_use and tool_result blocks always remain paired in the message history.

https://claude.ai/code/session_014ddGN4Rj8e8qYJhnm8svRS