### PR TITLE
fix(compaction): ignore cache_read_input_tokens in threshold check

### DIFF
--- a/src/agentlys/compaction.py
+++ b/src/agentlys/compaction.py
@@ -42,12 +42,21 @@ DEFAULT_COMPACTION_PROMPT = (
 class TokenThresholdCompaction:
     """Client-side compaction using a cheap model for summarization.
 
-    Checks the most recent API response's ``usage.input_tokens`` against a
-    configurable threshold. When exceeded, summarizes the entire conversation
-    into a single compaction message.
+    Checks the most recent API response's token usage against a configurable
+    threshold. When exceeded, summarizes the entire conversation into a single
+    compaction message.
+
+    ``should_compact`` measures *conversation growth* this turn —
+    ``input_tokens + cache_creation_input_tokens`` — and ignores
+    ``cache_read_input_tokens``. Cache reads are the stable prefix (system
+    prompt, tool definitions, cached history) that Anthropic's prompt-caching
+    layer already amortized; counting them would make the threshold fire on
+    every turn as soon as a cached prefix exists, even when the conversation
+    itself is barely growing. See:
+    https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
 
     Args:
-        token_threshold: Trigger compaction when input tokens exceed this value.
+        token_threshold: Trigger compaction when growth tokens exceed this value.
         summary_model: Model to use for generating summaries (cheap/fast recommended).
         instructions: Custom summarization prompt. Replaces the default if provided.
     """
@@ -59,17 +68,18 @@ class TokenThresholdCompaction:
     async def should_compact(self, chat: AgentlysBase) -> bool:
         """Check if compaction is needed based on the last API response's token usage.
 
-        Each assistant Message from the provider carries a ``usage`` dict.
-        Total input tokens includes cached tokens (cache_creation_input_tokens,
-        cache_read_input_tokens) which are separate from input_tokens when
-        prompt caching is enabled.
+        Walks ``chat.messages`` from the end and uses the first message that
+        carries a ``usage`` dict with ``input_tokens``. Sums
+        ``input_tokens + cache_creation_input_tokens`` — the new tokens this
+        turn either added to the cache or sent uncached, i.e. conversation
+        growth. ``cache_read_input_tokens`` is excluded because it's the
+        stable cached prefix and would otherwise push every post-cache turn
+        over a modest threshold.
         """
         for msg in reversed(chat.messages):
             if msg.usage and "input_tokens" in msg.usage:
-                total = (
-                    msg.usage["input_tokens"]
-                    + msg.usage.get("cache_creation_input_tokens", 0)
-                    + msg.usage.get("cache_read_input_tokens", 0)
+                total = msg.usage["input_tokens"] + msg.usage.get(
+                    "cache_creation_input_tokens", 0
                 )
                 return total > self.token_threshold
         return False
@@ -106,8 +116,7 @@ class TokenThresholdCompaction:
             {
                 "role": "user",
                 "content": (
-                    f"{prompt}\n\n"
-                    f"--- Conversation to summarize ---\n{conversation_str}"
+                    f"{prompt}\n\n--- Conversation to summarize ---\n{conversation_str}"
                 ),
             }
         ]

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -658,5 +658,107 @@ class TestCustomCompactionHandler(unittest.TestCase):
         self.assertIsInstance(compactor, CompactionHandler)
 
 
+class _StubChat:
+    """Minimal stand-in for AgentlysBase: only ``messages`` is read."""
+
+    def __init__(self, messages):
+        self.messages = messages
+
+
+class TestShouldCompactCacheAwareness(unittest.TestCase):
+    """The default mode must ignore ``cache_read_input_tokens`` (the bug fix).
+
+    A cached system prompt routinely contributes thousands of cache_read
+    tokens on every turn. Counting it made compaction fire every turn for
+    long-lived conversations with prompt caching enabled.
+    """
+
+    def _run(self, compaction, chat):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(compaction.should_compact(chat))
+        finally:
+            loop.close()
+
+    def test_no_messages_returns_false(self):
+        compaction = TokenThresholdCompaction(token_threshold=100)
+        self.assertFalse(self._run(compaction, _StubChat([])))
+
+    def test_last_message_without_usage_returns_false(self):
+        compaction = TokenThresholdCompaction(token_threshold=100)
+        chat = _StubChat([Message(role="user", content="Hi")])
+        self.assertFalse(self._run(compaction, chat))
+
+    def test_input_tokens_alone_above_threshold_returns_true(self):
+        compaction = TokenThresholdCompaction(token_threshold=100)
+        chat = _StubChat(
+            [
+                Message(
+                    role="assistant",
+                    content="ok",
+                    usage={"input_tokens": 150, "output_tokens": 10},
+                )
+            ]
+        )
+        self.assertTrue(self._run(compaction, chat))
+
+    def test_cache_read_alone_above_threshold_returns_false(self):
+        """The bug fix: a huge cached prefix must not trigger compaction."""
+        compaction = TokenThresholdCompaction(token_threshold=100)
+        chat = _StubChat(
+            [
+                Message(
+                    role="assistant",
+                    content="ok",
+                    usage={
+                        "input_tokens": 10,
+                        "cache_creation_input_tokens": 5,
+                        "cache_read_input_tokens": 5_000,
+                        "output_tokens": 10,
+                    },
+                )
+            ]
+        )
+        self.assertFalse(self._run(compaction, chat))
+
+    def test_input_plus_cache_creation_above_threshold_returns_true(self):
+        compaction = TokenThresholdCompaction(token_threshold=100)
+        chat = _StubChat(
+            [
+                Message(
+                    role="assistant",
+                    content="ok",
+                    usage={
+                        "input_tokens": 60,
+                        "cache_creation_input_tokens": 60,
+                        "cache_read_input_tokens": 0,
+                        "output_tokens": 10,
+                    },
+                )
+            ]
+        )
+        self.assertTrue(self._run(compaction, chat))
+
+    def test_finds_most_recent_message_with_usage(self):
+        """Older usage data must be skipped in favor of the latest turn."""
+        compaction = TokenThresholdCompaction(token_threshold=100)
+        chat = _StubChat(
+            [
+                Message(
+                    role="assistant",
+                    content="old",
+                    usage={"input_tokens": 9_999, "output_tokens": 10},
+                ),
+                Message(role="user", content="next"),
+                Message(
+                    role="assistant",
+                    content="new",
+                    usage={"input_tokens": 5, "output_tokens": 10},
+                ),
+            ]
+        )
+        self.assertFalse(self._run(compaction, chat))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- `TokenThresholdCompaction.should_compact` was summing `input_tokens + cache_creation_input_tokens + cache_read_input_tokens`. The cache-read tokens are the stable cached prefix (system prompt, tool defs, cached history) — already amortized by Anthropic's prompt-caching layer and not reflective of conversation growth.
- Once a cached prefix existed (typically several thousand tokens), the running total exceeded any small-to-mid threshold on every assistant turn, so compaction fired every turn. A long Myriade conversation paused ~2 minutes on each regenerate because the cached prefix kept pushing the total above 130_000.
- Fix: sum only `input_tokens + cache_creation_input_tokens` — the new tokens added this turn. Docstrings updated to explain why cache reads are excluded, with a link to Anthropic's prompt-caching docs.

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `pytest tests/test_compaction.py -q` → 37 passed
- [x] New `TestShouldCompactCacheAwareness` covers: empty messages, last message without usage, `input_tokens` alone over threshold (True), **`cache_read_input_tokens` alone over threshold (False — the bug fix)**, `input + cache_creation` over threshold (True), most-recent-usage iteration

🤖 Generated with [Claude Code](https://claude.com/claude-code)