### PR TITLE
feat(chat): per-call tool isolation seam (__agentlys_call_scope__)

### DIFF
--- a/src/agentlys/chat.py
+++ b/src/agentlys/chat.py
@@ -852,6 +852,25 @@ class Agentlys(AgentlysBase):
         return content
 
     async def _call_with_signature(self, func, from_response, **kwargs):
+        # Per-call isolation seam. A tool method runs concurrently with others
+        # in a turn — sync tools on worker threads (see below), async tools as
+        # interleaved tasks — yet they share the one tool instance. State on
+        # that instance which isn't safe to share (a DB session, an open
+        # transaction, a non-thread-safe client) then races across calls.
+        #
+        # If the tool owning this method exposes ``__agentlys_call_scope__`` (a
+        # context manager), run the call inside it and rebind the method to the
+        # instance it yields, so each concurrent invocation gets its own scope.
+        # Tools without it are unaffected; plain functions have no owner.
+        owner = getattr(func, "__self__", None)
+        call_scope = getattr(owner, "__agentlys_call_scope__", None)
+        if call_scope is not None:
+            with call_scope() as scoped_owner:
+                scoped_func = getattr(scoped_owner, func.__name__)
+                return await self._invoke_func(scoped_func, from_response, **kwargs)
+        return await self._invoke_func(func, from_response, **kwargs)
+
+    async def _invoke_func(self, func, from_response, **kwargs):
         sig = inspect.signature(func)
         if "from_response" in sig.parameters:
             kwargs = {**kwargs, "from_response": from_response}

--- a/src/agentlys/chat.py
+++ b/src/agentlys/chat.py
@@ -864,11 +864,42 @@ class Agentlys(AgentlysBase):
         # Tools without it are unaffected; plain functions have no owner.
         owner = getattr(func, "__self__", None)
         call_scope = getattr(owner, "__agentlys_call_scope__", None)
-        if call_scope is not None:
+        if call_scope is None:
+            return await self._invoke_func(func, from_response, **kwargs)
+
+        # Async tools run as tasks on the event loop, so opening the scope here
+        # and awaiting the body share one thread/task — enter the scope inline.
+        if self._is_async_callable(func):
             with call_scope() as scoped_owner:
                 scoped_func = getattr(scoped_owner, func.__name__)
                 return await self._invoke_func(scoped_func, from_response, **kwargs)
-        return await self._invoke_func(func, from_response, **kwargs)
+
+        # Sync tools are offloaded to a worker thread (see ``_invoke_func``), so
+        # the scope must open, run AND close on that same thread. Entering it on
+        # the event-loop thread would create/close a thread-affine resource (a
+        # SQLAlchemy ``Session``) on a different thread than the one the method
+        # body uses, defeating the "session per thread" isolation this provides.
+        def _run_scoped_sync():
+            with call_scope() as scoped_owner:
+                scoped_func = getattr(scoped_owner, func.__name__)
+                call_kwargs = kwargs
+                if "from_response" in inspect.signature(scoped_func).parameters:
+                    call_kwargs = {**kwargs, "from_response": from_response}
+                return scoped_func(**call_kwargs)
+
+        result = await asyncio.to_thread(_run_scoped_sync)
+        # Defensive: a sync wrapper may return a coroutine (eg a lambda around an
+        # async fn); await it on the event loop to preserve historical semantics.
+        if inspect.iscoroutine(result):
+            return await result
+        return result
+
+    @staticmethod
+    def _is_async_callable(func) -> bool:
+        return inspect.iscoroutinefunction(func) or (
+            callable(func)
+            and inspect.iscoroutinefunction(getattr(func, "__call__", None))
+        )
 
     async def _invoke_func(self, func, from_response, **kwargs):
         sig = inspect.signature(func)
@@ -876,10 +907,7 @@ class Agentlys(AgentlysBase):
             kwargs = {**kwargs, "from_response": from_response}
 
         # Async tools: await them directly on the event loop.
-        if inspect.iscoroutinefunction(func) or (
-            callable(func)
-            and inspect.iscoroutinefunction(getattr(func, "__call__", None))
-        ):
+        if self._is_async_callable(func):
             return await func(**kwargs)
 
         # Sync tools: offload to a worker thread so a slow call (network I/O,

--- a/tests/test_call_scope.py
+++ b/tests/test_call_scope.py
@@ -1,0 +1,135 @@
+"""Per-call isolation seam: ``__agentlys_call_scope__``.
+
+A turn's tool calls run concurrently — sync tools on worker threads, async
+tools as interleaved tasks — yet share one tool instance. Instance state that
+isn't safe to share (a DB session, an open transaction, a non-thread-safe
+client) then races across calls.
+
+When a tool exposes ``__agentlys_call_scope__`` (a context manager), each call
+runs on the instance it yields, so concurrent calls get isolated state. These
+tests drive the seam through ``_call_with_signature`` — the chokepoint every
+dispatch path funnels through.
+"""
+
+import asyncio
+import contextlib
+import copy
+import threading
+
+import pytest
+
+from agentlys import Agentlys
+from agentlys.chat import StopLoopException
+
+
+@pytest.fixture(autouse=True)
+def _fake_api_keys(monkeypatch):
+    # Agentlys() builds an OpenAI client eagerly; these tests never hit the wire.
+    monkeypatch.setenv("OPENAI_API_KEY", "fake")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake")
+
+
+class _ScopedTool:
+    """Hands each call its own ``session`` via the scope; records lifecycle."""
+
+    def __init__(self):
+        self.session = None  # shared state that must NOT be reused across calls
+        self.entered = []
+        self.exited = []
+        self._lock = threading.Lock()
+
+    @contextlib.contextmanager
+    def __agentlys_call_scope__(self):
+        scoped = copy.copy(self)
+        scoped.session = object()  # a distinct session per call
+        with self._lock:
+            self.entered.append(scoped.session)
+        try:
+            yield scoped
+        finally:
+            with self._lock:
+                self.exited.append(scoped.session)
+
+    def work(self, **kwargs):
+        # Runs on the scoped copy, so it sees that copy's own session.
+        assert self.session is not None, "tool ran without a scoped session"
+        return self.session
+
+    async def awork(self, **kwargs):
+        await asyncio.sleep(0.01)
+        assert self.session is not None
+        return self.session
+
+    def boom(self, **kwargs):
+        raise ValueError("kaboom")
+
+    def stop(self, **kwargs):
+        raise StopLoopException("done")
+
+
+class _PlainTool:
+    """No scope → calls run on the original instance (current behaviour)."""
+
+    def __init__(self):
+        self.marker = "original"
+
+    def work(self, **kwargs):
+        return self.marker
+
+
+@pytest.mark.asyncio
+async def test_scope_runs_method_on_scoped_instance():
+    chat = Agentlys()
+    tool = _ScopedTool()
+    session = await chat._call_with_signature(tool.work, None)
+    assert session is not None
+    assert tool.session is None, "the original instance must stay untouched"
+    assert len(tool.entered) == len(tool.exited) == 1
+
+
+@pytest.mark.asyncio
+async def test_parallel_sync_calls_get_isolated_sessions():
+    chat = Agentlys()
+    tool = _ScopedTool()
+    n = 12
+    sessions = await asyncio.gather(
+        *[chat._call_with_signature(tool.work, None) for _ in range(n)]
+    )
+    assert len({id(s) for s in sessions}) == n, "calls shared a session"
+    assert len(tool.entered) == len(tool.exited) == n
+
+
+@pytest.mark.asyncio
+async def test_parallel_async_calls_get_isolated_sessions():
+    chat = Agentlys()
+    tool = _ScopedTool()
+    n = 12
+    sessions = await asyncio.gather(
+        *[chat._call_with_signature(tool.awork, None) for _ in range(n)]
+    )
+    assert len({id(s) for s in sessions}) == n
+
+
+@pytest.mark.asyncio
+async def test_tool_without_scope_is_unaffected():
+    chat = Agentlys()
+    tool = _PlainTool()
+    assert await chat._call_with_signature(tool.work, None) == "original"
+
+
+@pytest.mark.asyncio
+async def test_exception_propagates_and_scope_exits():
+    chat = Agentlys()
+    tool = _ScopedTool()
+    with pytest.raises(ValueError):
+        await chat._call_with_signature(tool.boom, None)
+    assert len(tool.exited) == 1, "scope must exit (cleanup) even on error"
+
+
+@pytest.mark.asyncio
+async def test_stoploop_propagates_and_scope_exits():
+    chat = Agentlys()
+    tool = _ScopedTool()
+    with pytest.raises(StopLoopException):
+        await chat._call_with_signature(tool.stop, None)
+    assert len(tool.exited) == 1

--- a/tests/test_call_scope.py
+++ b/tests/test_call_scope.py
@@ -67,6 +67,50 @@ class _ScopedTool:
         raise StopLoopException("done")
 
 
+class _ThreadRecordingTool:
+    """Records the thread on which scope enter/exit and the body each run.
+
+    ``threads`` is a shared dict: the scope yields a shallow copy, so the copy
+    (which runs the body) and the original (which runs enter/exit) write into
+    the same dict.
+    """
+
+    def __init__(self):
+        self.session = None
+        self.threads = {}
+
+    @contextlib.contextmanager
+    def __agentlys_call_scope__(self):
+        scoped = copy.copy(self)
+        scoped.session = object()
+        self.threads["enter"] = threading.get_ident()
+        try:
+            yield scoped
+        finally:
+            self.threads["exit"] = threading.get_ident()
+
+    def work(self, **kwargs):
+        self.threads["body"] = threading.get_ident()
+        return self.session
+
+
+@pytest.mark.asyncio
+async def test_sync_scope_lifecycle_and_body_share_one_worker_thread():
+    # A thread-affine resource (eg a SQLAlchemy Session) must be opened, used
+    # and closed on the same thread. For sync tools that means the scope's
+    # enter/exit run on the worker thread alongside the offloaded body — never
+    # on the event-loop thread.
+    chat = Agentlys()
+    tool = _ThreadRecordingTool()
+    loop_thread = threading.get_ident()
+
+    await chat._call_with_signature(tool.work, None)
+
+    t = tool.threads
+    assert t["enter"] == t["body"] == t["exit"]
+    assert t["body"] != loop_thread, "sync body must run off the event loop"
+
+
 class _PlainTool:
     """No scope → calls run on the original instance (current behaviour)."""
 


### PR DESCRIPTION
## Problem

A turn's tool calls run **concurrently** — sync tools offloaded to worker threads (`asyncio.to_thread`), async tools as interleaved tasks — but they all share the one registered tool **instance**. Instance state that isn't safe to share across concurrent execution (a SQLAlchemy `Session`, an open transaction, a non-thread-safe client) then **races** between calls.

agentlys is what *introduces* that concurrency (`_call_functions_parallel` + the `to_thread` offload), so it's the right layer to provide the means to make it safe.

## Fix — a per-call isolation seam

If the tool owning the called method exposes **`__agentlys_call_scope__`** (a context manager), each call now runs *inside* it, and the method is rebound to the instance the scope yields — so every concurrent invocation gets its own scope.

- Hook lives at **`_call_with_signature`**, the single chokepoint every dispatch path funnels through.
- The owning instance is recovered from the bound method's `__self__`; the method is re-resolved on the scoped instance by name.
- The scope wraps the call **including** the `to_thread`/`await`, so it covers sync (threads) *and* async (tasks).
- **Fully backward-compatible:** tools without the hook are unaffected; plain (non-method) functions have no `__self__` and fall through unchanged. The hook name starts with `_`, so `add_tool` never registers it as a tool.

agentlys stays agnostic about *what* the scope isolates — the consumer's context manager owns lifecycle/transaction policy (open / commit / rollback / close). Example consumer:

```python
class SessionScopedTool:
    @contextmanager
    def __agentlys_call_scope__(self):
        s = SessionLocal()
        scoped = copy.copy(self); scoped.session = s
        try:
            yield scoped
            s.commit()
        except StopLoopException:   # control signal, not an error
            s.commit(); raise
        except Exception:
            s.rollback(); raise
        finally:
            s.close()
```

## Tests

`tests/test_call_scope.py` (6 tests, no wire): scope runs the method on the scoped instance and leaves the original untouched; **parallel sync calls** and **parallel async calls** each get isolated state; tools without the hook are unaffected; exceptions and `StopLoopException` both propagate while the scope still exits (so consumers can commit/rollback). Sibling `test_sync_tool_offload.py` (the related to_thread regression) stays green.

## Why

Downstream (Myriade), every agent tool shares one SQLAlchemy `Session`; concurrent catalog reads raised `InvalidRequestError: This session is provisioning a new connection` on multi-tool turns. SQLAlchemy's model is "Session per thread, AsyncSession per task" — there's no safe way to share one across parallel calls. This seam lets the consumer give each call its own session with zero per-tool changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)