### PR TITLE
feat(mcp): harden MCP client tool integration

### DIFF
--- a/src/agentlys/chat.py
+++ b/src/agentlys/chat.py
@@ -172,9 +172,7 @@ class Agentlys(AgentlysBase):
         if self.cancel_event is not None and self.cancel_event.is_set():
             raise StopLoopException("Cancelled via cancel_event")
 
-    def _is_tool_result_message(
-        self, message: typing.Optional[Message]
-    ) -> bool:
+    def _is_tool_result_message(self, message: typing.Optional[Message]) -> bool:
         """True if the message carries tool/function results.
 
         Compaction must not run when the next message is a tool result, because
@@ -202,13 +200,9 @@ class Agentlys(AgentlysBase):
         last = self.messages[-1]
         if last.role != "assistant":
             return False
-        return any(
-            part.type == "function_call" for part in (last.parts or [])
-        )
+        return any(part.type == "function_call" for part in (last.parts or []))
 
-    async def _maybe_compact(
-        self, next_message: typing.Optional[Message]
-    ) -> bool:
+    async def _maybe_compact(self, next_message: typing.Optional[Message]) -> bool:
         """Run compaction if safe. Returns True if compaction executed."""
         if not (self.compaction and hasattr(self.compaction, "should_compact")):
             return False
@@ -283,8 +277,7 @@ class Agentlys(AgentlysBase):
             if self._tool_search_config:
                 prefix = f"{tool_name}__"
                 has_loaded_method = any(
-                    s["name"].startswith(prefix)
-                    and not s.get("defer_loading")
+                    s["name"].startswith(prefix) and not s.get("defer_loading")
                     for s in self.functions_schema
                 )
                 if not has_loaded_method:
@@ -318,9 +311,7 @@ class Agentlys(AgentlysBase):
         if not self._tool_search_config:
             return None
 
-        deferred = [
-            s for s in self.functions_schema if s.get("defer_loading")
-        ]
+        deferred = [s for s in self.functions_schema if s.get("defer_loading")]
         if not deferred:
             return None
 
@@ -395,8 +386,7 @@ class Agentlys(AgentlysBase):
         if (
             self._tool_search_config
             and not defer_loading
-            and function_schema["name"]
-            not in self._tool_search_config.always_loaded
+            and function_schema["name"] not in self._tool_search_config.always_loaded
             and function_schema["name"] != self._tool_search_function_name
         ):
             function_schema["defer_loading"] = True
@@ -500,7 +490,9 @@ class Agentlys(AgentlysBase):
             run_agent = copy.copy(agent)
             run_agent.provider = copy.copy(agent.provider)
             run_agent.provider.chat = run_agent
-            if self.cancel_event is not None:  # Propagate cancellation, preserve child's own event
+            if (
+                self.cancel_event is not None
+            ):  # Propagate cancellation, preserve child's own event
                 run_agent.cancel_event = self.cancel_event
             run_agent.messages = []
 
@@ -585,9 +577,7 @@ class Agentlys(AgentlysBase):
         del self._sub_agents[func_name]
         self.functions.pop(func_name, None)
         self.functions_schema = [
-            schema
-            for schema in self.functions_schema
-            if schema["name"] != func_name
+            schema for schema in self.functions_schema if schema["name"] != func_name
         ]
 
     def enable_tool_search(
@@ -661,20 +651,70 @@ class Agentlys(AgentlysBase):
         self._tool_search_function_name = search_schema["name"]
         self.add_function(search_callable, search_schema)
 
-    async def add_mcp_server(self, mcp_server):
+    async def add_mcp_server(
+        self,
+        mcp_server,
+        prefix: str = "",
+        tool_filter: typing.Optional[typing.Callable] = None,
+        max_result_chars: typing.Optional[int] = None,
+        include_resources: bool = True,
+    ) -> list[str]:
         """
         Add a MCP server to the agent instance.
         The MCP server will be used to call tools and resources.
+
+        Args:
+            mcp_server: An initialized MCP ``ClientSession`` (or any object
+                exposing the same ``list_tools`` / ``call_tool`` /
+                ``list_resources`` interface).
+            prefix: Namespace prefix applied to every registered name so
+                tools from different servers (or built-in tools) never
+                collide.
+            tool_filter: Optional callable receiving the MCP ``Tool``
+                object; return False to skip the tool.
+            max_result_chars: Optional cap on tool/resource result size.
+            include_resources: Also expose the server's resources as
+                functions (default True, matching historical behavior).
+
+        Returns:
+            The list of registered function names. Names already taken by
+            existing functions are skipped (with a warning), so MCP servers
+            can never shadow built-in tools.
         """
         from agentlys.mcp import fetch_mcp_server_resources, fetch_mcp_server_tools
 
-        logging.warning("Experimental feature: MCP servers")
-        tools_functions, schemas = await fetch_mcp_server_tools(mcp_server)
-        self.functions.update(tools_functions)
-        self.functions_schema.extend(schemas)
-        resources_functions, schemas = await fetch_mcp_server_resources(mcp_server)
-        self.functions.update(resources_functions)
-        self.functions_schema.extend(schemas)
+        registered: list[str] = []
+
+        batches = [
+            await fetch_mcp_server_tools(
+                mcp_server,
+                prefix=prefix,
+                tool_filter=tool_filter,
+                max_result_chars=max_result_chars,
+            )
+        ]
+        if include_resources:
+            batches.append(
+                await fetch_mcp_server_resources(
+                    mcp_server,
+                    prefix=prefix,
+                    max_result_chars=max_result_chars,
+                )
+            )
+
+        # Route through add_function so tool-search auto-deferral applies
+        # and the registration behaves like any other tool.
+        for functions, schemas in batches:
+            for schema in schemas:
+                if schema["name"] in self.functions:
+                    logging.warning(
+                        "MCP name %r collides with an existing function, skipping",
+                        schema["name"],
+                    )
+                    continue
+                self.add_function(functions[schema["name"]], schema)
+                registered.append(schema["name"])
+        return registered
 
     async def ask_async(
         self,

--- a/src/agentlys/mcp.py
+++ b/src/agentlys/mcp.py
@@ -1,44 +1,137 @@
+import json
+import logging
+import re
+import typing
+
 from mcp import ClientSession
 
+logger = logging.getLogger(__name__)
 
-async def fetch_mcp_server_tools(mcp_server: ClientSession):
+# Anthropic and OpenAI both constrain tool names to this charset and length.
+TOOL_NAME_MAX_LENGTH = 64
+_TOOL_NAME_SANITIZE_RE = re.compile(r"[^a-zA-Z0-9_-]")
+
+# Filter signature: receives the MCP Tool object, returns True to expose it.
+ToolFilter = typing.Callable[[typing.Any], bool]
+
+
+def sanitize_tool_name(name: str, prefix: str = "") -> str:
+    """Make an MCP tool name safe for LLM providers.
+
+    Applies the optional namespace prefix, replaces characters outside
+    ``[a-zA-Z0-9_-]`` with ``_`` and truncates to the provider limit.
     """
-    Fetch the tools from the MCP server and add them to the chat instance.
+    sanitized = _TOOL_NAME_SANITIZE_RE.sub("_", f"{prefix}{name}")
+    return sanitized[:TOOL_NAME_MAX_LENGTH]
+
+
+def convert_tool_result(result, max_result_chars: typing.Optional[int] = None) -> str:
+    """Convert an MCP ``CallToolResult`` into a string for the LLM.
+
+    Handles multiple content blocks, non-text blocks, structured content,
+    ``isError`` results and optional truncation. Never raises on the result
+    shape so a misbehaving server cannot crash the agent loop.
+    """
+    parts: list[str] = []
+    for block in getattr(result, "content", None) or []:
+        block_type = getattr(block, "type", "unknown")
+        if block_type == "text":
+            parts.append(block.text or "")
+        else:
+            parts.append(f"[{block_type} content omitted]")
+
+    text = "\n".join(part for part in parts if part)
+
+    if not text:
+        structured = getattr(result, "structuredContent", None)
+        if structured is not None:
+            try:
+                text = json.dumps(structured, default=str)
+            except (TypeError, ValueError):
+                text = str(structured)
+
+    if getattr(result, "isError", False):
+        text = f"MCP tool error: {text or 'unknown error'}"
+
+    if not text:
+        text = "(empty result)"
+
+    if max_result_chars is not None and len(text) > max_result_chars:
+        text = (
+            text[:max_result_chars]
+            + f"\n[... truncated to {max_result_chars} characters."
+            + " Refine the call (filters, pagination) to get less data.]"
+        )
+    return text
+
+
+async def fetch_mcp_server_tools(
+    mcp_server: ClientSession,
+    prefix: str = "",
+    tool_filter: typing.Optional[ToolFilter] = None,
+    max_result_chars: typing.Optional[int] = None,
+):
+    """
+    Fetch the tools from the MCP server and return (functions, schemas).
+
+    Args:
+        mcp_server: An initialized MCP ``ClientSession``.
+        prefix: Namespace prefix applied to every tool name (collision
+            protection when multiple servers — or built-in tools — coexist).
+        tool_filter: Optional callable receiving the MCP ``Tool`` object;
+            return False to skip the tool (host-side allowlisting / pinning).
+        max_result_chars: Optional cap on the size of tool results.
     """
     schemas = []
     functions = {}
     tools = (await mcp_server.list_tools()).tools
 
     for tool in tools:
-        functions_schema = tool.model_dump()
-        functions_schema["parameters"] = functions_schema.pop("inputSchema")
+        if tool_filter is not None and not tool_filter(tool):
+            continue
+
+        name = sanitize_tool_name(tool.name, prefix)
+        if name in functions:
+            logger.warning("Duplicate MCP tool name %r, skipping", name)
+            continue
+
+        # Only keep the keys agentlys understands: extra metadata from the
+        # server (annotations, icons, ...) is untrusted and unused.
+        functions_schema = {
+            "name": name,
+            "description": tool.description or "",
+            "parameters": tool.inputSchema or {"type": "object", "properties": {}},
+        }
         schemas.append(functions_schema)
 
         # add function that will encapsulate the call to the tool
         def call_tool_wrapper(function_name):
             async def call_tool(**kwargs):
                 result = await mcp_server.call_tool(function_name, arguments=kwargs)
-                # NOTE: for now, we only return the text of the result
-                return result.content[0].text
+                return convert_tool_result(result, max_result_chars=max_result_chars)
 
             return call_tool
 
-        call_tool = call_tool_wrapper(functions_schema["name"])
-        functions[functions_schema["name"]] = call_tool
+        # call_tool uses the server-side (unprefixed) tool name
+        functions[name] = call_tool_wrapper(tool.name)
 
     return functions, schemas
 
 
-async def fetch_mcp_server_resources(mcp_server: ClientSession):
+async def fetch_mcp_server_resources(
+    mcp_server: ClientSession,
+    prefix: str = "",
+    max_result_chars: typing.Optional[int] = None,
+):
     """
-    Fetch the resources from the MCP server and add them to the chat instance.
+    Fetch the resources from the MCP server and return (functions, schemas).
     """
     schemas = []
     functions = {}
     resources = (await mcp_server.list_resources()).resources
     resources += (await mcp_server.list_resource_templates()).resourceTemplates
 
-    def extract_parameters_from_uri(uri: str) -> dict:
+    def extract_parameters_from_uri(uri: str) -> list:
         # example of uri: users://{user_id}/profile/{profile_id}
         # in this case, we want to return ["user_id", "profile_id"]
         return [
@@ -48,18 +141,25 @@ async def fetch_mcp_server_resources(mcp_server: ClientSession):
         ]
 
     for resource in resources:
-        if hasattr(resource, "uriTemplate"):
+        if getattr(resource, "uriTemplate", None):
             uri = str(resource.uriTemplate)
-        elif hasattr(resource, "uri"):
+        elif getattr(resource, "uri", None):
             uri = str(resource.uri)
         else:
             raise ValueError(f"Invalid resource: {resource}")
 
         parameters = extract_parameters_from_uri(uri)
         description = "uri:" + uri
-        name = (
-            uri.replace("://", "__").replace("/", "_").replace("{", "").replace("}", "")
+        name = sanitize_tool_name(
+            uri.replace("://", "__")
+            .replace("/", "_")
+            .replace("{", "")
+            .replace("}", ""),
+            prefix,
         )
+        if name in functions:
+            logger.warning("Duplicate MCP resource name %r, skipping", name)
+            continue
         if resource.description:
             description += "\n" + resource.description
 
@@ -76,7 +176,7 @@ async def fetch_mcp_server_resources(mcp_server: ClientSession):
         }
         schemas.append(functions_schema)
 
-        # add function that will encapsulate the call to the tool
+        # add function that will encapsulate the call to the resource
         def read_resource_wrapper(uri_template):
             async def read_resource(**kwargs):
                 # Reconstruct the uri from the function name
@@ -84,8 +184,20 @@ async def fetch_mcp_server_resources(mcp_server: ClientSession):
                 for key in kwargs:
                     uri = uri.replace("{" + key + "}", kwargs[key])
                 result = await mcp_server.read_resource(uri)
-                # NOTE: for now, we only return the text of the result
-                return result.contents[0].text
+                parts = []
+                for content in getattr(result, "contents", None) or []:
+                    text = getattr(content, "text", None)
+                    if text is not None:
+                        parts.append(text)
+                    else:
+                        parts.append("[binary content omitted]")
+                text = "\n".join(parts) or "(empty result)"
+                if max_result_chars is not None and len(text) > max_result_chars:
+                    text = (
+                        text[:max_result_chars]
+                        + f"\n[... truncated to {max_result_chars} characters.]"
+                    )
+                return text
 
             return read_resource
 

--- a/tests/mcp_clients/test_mcp_fetch.py
+++ b/tests/mcp_clients/test_mcp_fetch.py
@@ -1,0 +1,168 @@
+"""Unit tests for the MCP client glue (no LLM calls).
+
+Uses an in-process FastMCP server over memory streams, so the full
+list_tools/call_tool round-trip is exercised without subprocesses.
+"""
+
+import pytest
+from agentlys import Agentlys
+from agentlys.mcp import (
+    convert_tool_result,
+    fetch_mcp_server_tools,
+    sanitize_tool_name,
+)
+from mcp.server.fastmcp import FastMCP
+from mcp.shared.memory import create_connected_server_and_client_session
+from mcp.types import CallToolResult, TextContent
+
+
+def make_server() -> FastMCP:
+    mcp = FastMCP("Test")
+
+    @mcp.tool()
+    def add(a: int, b: int) -> int:
+        """Add two numbers"""
+        return a + b
+
+    @mcp.tool()
+    def boom() -> str:
+        """Always fails"""
+        raise ValueError("kaboom")
+
+    @mcp.tool()
+    def long_output(n: int) -> str:
+        """Return n characters"""
+        return "x" * n
+
+    @mcp.tool(name="weird.name/check")
+    def weird() -> str:
+        """Tool with a name LLM providers reject"""
+        return "ok"
+
+    return mcp
+
+
+def test_sanitize_tool_name():
+    assert sanitize_tool_name("add") == "add"
+    assert sanitize_tool_name("add", prefix="srv__") == "srv__add"
+    assert sanitize_tool_name("weird.name/check") == "weird_name_check"
+    assert len(sanitize_tool_name("x" * 100, prefix="p__")) == 64
+
+
+def test_convert_tool_result_multiple_blocks():
+    result = CallToolResult(
+        content=[
+            TextContent(type="text", text="part one"),
+            TextContent(type="text", text="part two"),
+        ]
+    )
+    assert convert_tool_result(result) == "part one\npart two"
+
+
+def test_convert_tool_result_empty_and_structured():
+    assert convert_tool_result(CallToolResult(content=[])) == "(empty result)"
+    result = CallToolResult(content=[], structuredContent={"answer": 42})
+    assert convert_tool_result(result) == '{"answer": 42}'
+
+
+def test_convert_tool_result_error():
+    result = CallToolResult(
+        content=[TextContent(type="text", text="it broke")], isError=True
+    )
+    assert convert_tool_result(result) == "MCP tool error: it broke"
+
+
+def test_convert_tool_result_truncation():
+    result = CallToolResult(content=[TextContent(type="text", text="x" * 500)])
+    converted = convert_tool_result(result, max_result_chars=100)
+    assert converted.startswith("x" * 100)
+    assert "truncated to 100 characters" in converted
+    assert len(converted) < 250
+
+
+@pytest.mark.asyncio
+async def test_fetch_tools_prefix_sanitization_and_call():
+    server = make_server()
+    async with create_connected_server_and_client_session(
+        server._mcp_server
+    ) as session:
+        functions, schemas = await fetch_mcp_server_tools(session, prefix="mcp_demo__")
+        names = {schema["name"] for schema in schemas}
+        assert "mcp_demo__add" in names
+        assert "mcp_demo__weird_name_check" in names
+        # only the keys agentlys understands survive (untrusted extras dropped)
+        assert all(
+            set(schema) == {"name", "description", "parameters"} for schema in schemas
+        )
+        # the wrapper calls the ORIGINAL (unprefixed) server-side name
+        assert await functions["mcp_demo__add"](a=1, b=2) == "3"
+        assert await functions["mcp_demo__weird_name_check"]() == "ok"
+
+
+@pytest.mark.asyncio
+async def test_fetch_tools_filter():
+    server = make_server()
+    async with create_connected_server_and_client_session(
+        server._mcp_server
+    ) as session:
+        functions, schemas = await fetch_mcp_server_tools(
+            session, tool_filter=lambda tool: tool.name == "add"
+        )
+        assert [schema["name"] for schema in schemas] == ["add"]
+        assert list(functions) == ["add"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_tools_error_result_does_not_raise():
+    server = make_server()
+    async with create_connected_server_and_client_session(
+        server._mcp_server
+    ) as session:
+        functions, _ = await fetch_mcp_server_tools(session)
+        result = await functions["boom"]()
+        assert result.startswith("MCP tool error:")
+        assert "kaboom" in result
+
+
+@pytest.mark.asyncio
+async def test_fetch_tools_result_cap():
+    server = make_server()
+    async with create_connected_server_and_client_session(
+        server._mcp_server
+    ) as session:
+        functions, _ = await fetch_mcp_server_tools(session, max_result_chars=50)
+        result = await functions["long_output"](n=5000)
+        assert "truncated to 50 characters" in result
+        assert len(result) < 200
+
+
+@pytest.mark.asyncio
+async def test_add_mcp_server_defers_with_tool_search(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    server = make_server()
+    async with create_connected_server_and_client_session(
+        server._mcp_server
+    ) as session:
+        agent = Agentlys(provider="anthropic")
+
+        def dummy() -> str:
+            """A built-in tool"""
+            return "x"
+
+        agent.add_function(dummy)
+        agent.enable_tool_search(always_loaded=["dummy"])
+
+        registered = await agent.add_mcp_server(
+            session, prefix="srv__", include_resources=False
+        )
+        assert "srv__add" in registered
+        schema = next(s for s in agent.functions_schema if s["name"] == "srv__add")
+        # tools added after enable_tool_search are auto-deferred
+        assert schema.get("defer_loading") is True
+        assert agent.functions["srv__add"] is not None
+
+        # re-registering the same server never duplicates nor shadows
+        assert (
+            await agent.add_mcp_server(session, prefix="srv__", include_resources=False)
+            == []
+        )


### PR DESCRIPTION
## What

Hardens the experimental MCP client glue so hosts (Myriade) can safely expose third-party MCP servers' tools to an agent:

- **Namespace prefix + name sanitization** — `add_mcp_server(session, prefix="mcp_acme__")` prefixes every registered tool/resource and sanitizes names to the provider charset (`[a-zA-Z0-9_-]`, ≤64 chars), so multiple servers and built-in tools can never collide.
- **`tool_filter` hook** — callable receiving the MCP `Tool` object; lets the host allowlist tools or enforce pinned-definition checks (rug-pull defense) without agentlys knowing the policy.
- **Robust `CallToolResult` conversion** — handles `isError` (returned as an error string instead of crashing on `content[0].text`), multiple/non-text content blocks, `structuredContent` fallback, empty results, and an optional `max_result_chars` cap with a truncation notice.
- **`add_mcp_server` routes through `add_function`** — tool-search auto-deferral now applies to MCP tools (they don't bloat the context when tool search is enabled), names already registered are skipped (MCP servers can never shadow built-in tools), and the method returns the list of registered names. New `include_resources` opt-out.

Backward compatible: existing `add_mcp_server(session)` call sites keep working.

## Tests

`tests/mcp_clients/test_mcp_fetch.py` — 10 new tests against an in-process FastMCP server over memory streams (no LLM, no VCR): sanitization, prefixing, filtering, error results, truncation, structured content, tool-search deferral, duplicate-registration protection.

Full suite: 186 passed (was 176), same 33 pre-existing env-dependent failures as master.

## Release note

Myriade's MCP connectors feature (myriade-private PR) depends on these kwargs — needs a **1.14.0 release** to unblock it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
