### PR TITLE
fix(compaction): skip compaction when response has no text block (DEV-1304)

### DIFF
--- a/src/agentlys/compaction.py
+++ b/src/agentlys/compaction.py
@@ -133,7 +133,15 @@ class TokenThresholdCompaction:
             (block for block in response.content if block.type == "text"), None
         )
         if text_block is None:
-            raise RuntimeError("Compaction response contained no text block")
+            # The summarizer occasionally returns no text block (e.g. an empty
+            # or thinking-only response). Skip compaction this round instead of
+            # crashing the agent turn; the conversation is left intact and
+            # compaction is retried on the next response that exceeds the
+            # threshold.
+            logger.warning(
+                "Compaction response contained no text block; skipping compaction"
+            )
+            return
         summary_text = text_block.text
 
         # Try to extract from <summary> tags if present

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -339,6 +339,44 @@ class TestTokenThresholdCompactionCompact(unittest.TestCase):
         self.assertEqual(len(agent.messages), 1)
         self.assertTrue(agent.messages[0].has_compaction)
 
+    def test_compact_skips_when_no_text_block(self):
+        """If the summarizer returns no text block (e.g. a thinking-only or
+        empty response), skip compaction instead of raising — the conversation
+        must stay intact so the agent turn does not crash (DEV-1304)."""
+        compaction = TokenThresholdCompaction()
+        agent = Agentlys(
+            instruction="Test", provider=APIProvider.ANTHROPIC, compaction=compaction
+        )
+        original_messages = [
+            Message(role="user", content="First message"),
+            Message(role="assistant", content="First response"),
+            Message(role="user", content="Second message"),
+            Message(role="assistant", content="Second response"),
+        ]
+        agent.messages = list(original_messages)
+
+        # Response carries only a non-text (thinking) block — no text block.
+        mock_thinking_block = MagicMock()
+        mock_thinking_block.type = "thinking"
+        mock_response = MagicMock()
+        mock_response.content = [mock_thinking_block]
+
+        agent.provider.client = MagicMock()
+        agent.provider.client.messages.create = AsyncMock(return_value=mock_response)
+
+        loop = asyncio.new_event_loop()
+        try:
+            # Must not raise RuntimeError.
+            loop.run_until_complete(compaction.compact(agent))
+        finally:
+            loop.close()
+
+        # Conversation left untouched: no compaction message inserted.
+        self.assertEqual(len(agent.messages), len(original_messages))
+        self.assertFalse(
+            any(getattr(m, "has_compaction", False) for m in agent.messages)
+        )
+
     def test_compact_extracts_summary_without_tags(self):
         """When the model doesn't use summary tags, use the full response."""
         compaction = TokenThresholdCompaction()


### PR DESCRIPTION
Closes DEV-1304

## Executed plan
1. Traced the Sentry signature (`RuntimeError: Compaction response contained no text block`) to `src/agentlys/compaction.py`: `TokenThresholdCompaction.compact()` selects the first `text` block from the summarizer response and `raise`d a `RuntimeError` when none was present. Because `compact()` is awaited from `Chat._maybe_compact()` (chat.py:736) with its result unused, that exception propagates up the agent loop and crashes the entire turn — surfacing in the app as the generic `domains.chat.api` "Background agent error".
2. Confirmed the failure mode is recoverable and non-fatal: the summarizer (a cheap Haiku call) can occasionally return a response with no text block (empty, or thinking-only). The correct degradation is to *skip* compaction for this round rather than abort the user's turn.
3. Replaced the `raise` with a `logger.warning(...)` + early `return`, leaving `chat.messages` untouched. Compaction is re-attempted on the next response whose `input_tokens` still exceed the threshold, so a transient empty summary self-heals. This mirrors the function's existing early-return guards (`if not messages: return`).
4. Added a regression test `test_compact_skips_when_no_text_block` to `tests/test_compaction.py`: a mocked summarizer returns a response containing only a non-text (thinking) block; the test asserts `compact()` does not raise and the conversation is left intact (no compaction message inserted).

## What's remaining to test
- [x] `tests/test_compaction.py` — full module passes (32 tests, including the new one) via `python -m unittest tests.test_compaction`. The new test's warning log is emitted as expected.
- [x] `ruff check` clean on both changed files.
- [ ] Full `pytest` suite / CI — **could not run end-to-end in this remote env**: the dev dependency group pins `vcrpy` to a git URL that the sandbox proxy blocks (403), so `uv sync`/`pytest` (which loads `conftest.py`'s `pytest-recording` hook) can't bootstrap. I ran the affected tests via `unittest` instead. Please confirm green in CI.
- [ ] Optional: sanity-check in a real session that a deliberately-empty summarizer response now logs the warning and the turn completes instead of erroring.

## Solutions / trade-offs that need attention
- **Skip vs. retry:** I chose "skip this round" (minimal, no extra cost). An alternative is to retry the summarizer once before giving up. Skip is simpler and self-heals on the next over-threshold response; the only downside is the conversation stays uncompacted slightly longer, which is strictly better than crashing. Flagging in case you'd prefer a bounded retry.
- **Unbounded-growth edge case:** if the summarizer *persistently* returns no text block, compaction would keep skipping and context would keep growing until the main model call hits its own context limit. That pre-existing risk is unchanged by this PR (previously it crashed immediately instead), and it's now observable via the warning log. A follow-up could add a retry/backoff or a hard fallback (e.g. truncate oldest messages) — out of scope for this crash hotfix.
- **Pre-existing ruff-format drift:** `ruff format --check` wants to reformat an *unrelated* string-concat block (lines ~106–110, untouched by this PR) — a ruff-version mismatch in the repo, not introduced here. Left as-is per "minimum changes necessary"; worth a separate formatting pass.

## Signal context
- Sentry: https://sentry.io/organizations/myriade-ai/issues/129899085/ (customer jules, release 2.88.1)
- BetterStack source: n/a (surfaced via Sentry; manifests as `domains.chat.api` "Background agent error")
- 24h occurrence count at time of fix: 1 event / 1 user (first seen 2026-06-23T19:55Z)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJCy2JHrjKmhTthmEdnT6e)_