### PR TITLE
feat(providers): support any OpenAI-compatible API

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,12 @@ agent = Agentlys(provider="anthropic", model="claude-sonnet-4-20250514")
 
 # OpenAI
 agent = Agentlys(model="gpt-4o")
+
+# Any OpenAI-compatible API (Ollama, vLLM, LiteLLM, OpenRouter, ...)
+agent = Agentlys(model="llama3.1", base_url="http://localhost:11434/v1")
 ```
+
+See the [Provider Guide](docs/providers.md) for details.
 
 ---
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -13,9 +13,11 @@ Agentlys(
     context: str = None,
     max_interactions: int = 100,
     model: str = None,
-    provider: str | Type[BaseProvider] = APIProvider.OPENAI,
+    provider: str | Type[BaseProvider] | None = None,
     use_tools_only: bool = False,
-    mcp_servers: list[object] = []
+    mcp_servers: list[object] = [],
+    base_url: str = None,
+    api_key: str = None
 )
 ```
 
@@ -28,9 +30,11 @@ Agentlys(
 - `context`: Additional context for the agent
 - `max_interactions`: Maximum number of interactions in a conversation (default: 100)
 - `model`: Model to use (defaults to env var AGENTLYS_MODEL)
-- `provider`: LLM provider ("openai", "anthropic", or custom provider class)
+- `provider`: LLM provider ("openai", "anthropic", or custom provider class). Defaults to env var AGENTLYS_PROVIDER, then "openai"
 - `use_tools_only`: Beta feature - agent only uses tools, no LLM calls
 - `mcp_servers`: List of MCP server connections
+- `base_url`: Custom API endpoint — with `provider="openai"`, any OpenAI-compatible API works (Ollama, vLLM, LiteLLM, OpenRouter, ...). Defaults to env var AGENTLYS_HOST
+- `api_key`: API key for the endpoint. Defaults to env var AGENTLYS_API_KEY, then the provider's own env var
 
 ### Core Methods
 
@@ -239,7 +243,9 @@ APIProvider.OPENAI_FUNCTION_LEGACY  # Legacy OpenAI function calling
 ## Environment Variables
 
 - `AGENTLYS_MODEL`: Default model to use
-- `AGENTLYS_HOST`: Custom provider endpoint
+- `AGENTLYS_PROVIDER`: Default provider ("openai", "anthropic", ...)
+- `AGENTLYS_HOST`: Custom provider endpoint (any OpenAI-compatible API with the openai provider)
+- `AGENTLYS_API_KEY`: API key for the custom endpoint
 - `AGENTLYS_OUTPUT_SIZE_LIMIT`: Maximum output size in characters (default: 4000)
 - `OPENAI_API_KEY`: OpenAI API key
 - `ANTHROPIC_API_KEY`: Anthropic API key

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -51,6 +51,48 @@ agent = Agentlys(provider="anthropic")
 agent = Agentlys(provider="anthropic", model="claude-sonnet-4-20250514")
 ```
 
+### Any OpenAI-Compatible API
+
+The `openai` provider works with any API that speaks the OpenAI chat
+completions protocol: Ollama, vLLM, LiteLLM, OpenRouter, Together, Groq,
+Azure-hosted gateways, self-hosted models, etc. Point it at your endpoint
+with `base_url` (and `api_key` if the endpoint requires one):
+
+```python
+# Ollama running locally (no API key needed)
+agent = Agentlys(
+    provider="openai",
+    model="llama3.1",
+    base_url="http://localhost:11434/v1",
+)
+
+# OpenRouter
+agent = Agentlys(
+    provider="openai",
+    model="meta-llama/llama-3.1-70b-instruct",
+    base_url="https://openrouter.ai/api/v1",
+    api_key="sk-or-...",
+)
+```
+
+Or configure everything through environment variables:
+
+```bash
+export AGENTLYS_PROVIDER="openai"
+export AGENTLYS_HOST="http://localhost:11434/v1"
+export AGENTLYS_API_KEY="optional-key"   # falls back to OPENAI_API_KEY
+export AGENTLYS_MODEL="llama3.1"
+```
+
+```python
+agent = Agentlys()  # picks everything up from the environment
+```
+
+Resolution order: explicit arguments > `AGENTLYS_*` env vars > provider
+defaults. When a custom endpoint is configured without any API key, a
+placeholder key is sent so key-less servers (Ollama, vLLM, ...) work out
+of the box.
+
 ### Custom Provider Host
 
 Use alternative endpoints or self-hosted models:

--- a/src/agentlys/base.py
+++ b/src/agentlys/base.py
@@ -5,7 +5,7 @@ from agentlys.providers.base_provider import BaseProvider
 
 
 class AgentlysBase:  # TODO: rename ?
-    instruction: str = (None,)
+    instruction: typing.Optional[str] = None
     examples: typing.Union[list[Message], None]
     messages: typing.Union[list[Message], None]
     context: str

--- a/src/agentlys/chat.py
+++ b/src/agentlys/chat.py
@@ -13,13 +13,16 @@ import traceback
 import typing
 import uuid
 import warnings
-from typing import TYPE_CHECKING, Type, Union
+from typing import TYPE_CHECKING, Type
 
 from PIL import Image as PILImage
 
 from agentlys.base import AgentlysBase
 from agentlys.model import Message, MessagePart
-from agentlys.providers.base_provider import APIProvider, BaseProvider
+from agentlys.providers.base_provider import (
+    APIProvider,  # noqa: F401  (re-exported via agentlys.__init__)
+    BaseProvider,
+)
 from agentlys.providers.utils import get_provider_and_model
 from agentlys.utils import (
     csv_dumps,
@@ -111,25 +114,40 @@ class Agentlys(AgentlysBase):
         user_context: str = None,
         max_interactions: int = 100,
         model=AGENTLYS_MODEL,
-        provider: Union[str, Type[BaseProvider]] = APIProvider.OPENAI,
+        provider: typing.Union[str, Type[BaseProvider], None] = None,
         use_tools_only: bool = False,
         mcp_servers: typing.Union[list[object], None] = [],
         thinking: typing.Optional[dict] = None,
         compaction: typing.Optional["CompactionHandler"] = None,
         cancel_event: typing.Optional[asyncio.Event] = None,
+        base_url: typing.Optional[str] = None,
+        api_key: typing.Optional[str] = None,
     ) -> None:
         """
         Initialize the Agentlys instance.
         Args:
+            provider: Union[str, Type[BaseProvider], None] = None,
+                Provider name ("openai", "anthropic", ...) or a custom
+                BaseProvider subclass. Defaults to the AGENTLYS_PROVIDER
+                environment variable, then "openai".
             use_tools_only: bool = False,
                 If True, the chat will only use tools and not the LLM.
                 This is a beta feature and may change in the future.
             thinking: Optional[dict] = None,
                 Extended thinking configuration for Anthropic models.
                 Example: {"type": "enabled", "budget_tokens": 10000}
+            base_url: Optional[str] = None,
+                Custom API endpoint. With provider="openai", any
+                OpenAI-compatible API can be used (Ollama, vLLM, LiteLLM,
+                OpenRouter, ...), e.g. "http://localhost:11434/v1".
+                Defaults to the AGENTLYS_HOST environment variable.
+            api_key: Optional[str] = None,
+                API key for the endpoint. Defaults to the AGENTLYS_API_KEY
+                environment variable, then the provider's own env var
+                (OPENAI_API_KEY / ANTHROPIC_API_KEY).
         """
         self.provider, self.model = get_provider_and_model(
-            self, provider, model
+            self, provider, model, base_url=base_url, api_key=api_key
         )  # TODO: rename register ?
         self.simple_response_callback = simple_response_default_callback
         if use_tools_only:

--- a/src/agentlys/chat.py
+++ b/src/agentlys/chat.py
@@ -34,7 +34,6 @@ from agentlys.utils import (
 if TYPE_CHECKING:
     from agentlys.compaction import CompactionHandler
 
-AGENTLYS_HOST = os.getenv("AGENTLYS_HOST")
 AGENTLYS_MODEL = os.getenv("AGENTLYS_MODEL")
 OUTPUT_SIZE_LIMIT = int(os.getenv("AGENTLYS_OUTPUT_SIZE_LIMIT", 20_000))
 
@@ -155,7 +154,6 @@ class Agentlys(AgentlysBase):
                 "use_tools_only is a beta feature and may change in the future"
             )
         self.use_tools_only = use_tools_only
-        self.client = None  # TODO:
         self.name = name
         self.instruction = instruction
         if examples is None:

--- a/src/agentlys/compaction.py
+++ b/src/agentlys/compaction.py
@@ -46,14 +46,19 @@ class TokenThresholdCompaction:
     configurable threshold. When exceeded, summarizes the entire conversation
     into a single compaction message.
 
+    Works with any provider implementing ``BaseProvider.complete()``
+    (Anthropic, OpenAI, and any OpenAI-compatible API).
+
     Args:
         token_threshold: Trigger compaction when input tokens exceed this value.
-        summary_model: Model to use for generating summaries (cheap/fast recommended).
+        summary_model: Model to use for generating summaries (cheap/fast
+            recommended). Defaults to the provider's current model — pass a
+            cheap model explicitly to reduce summarization cost.
         instructions: Custom summarization prompt. Replaces the default if provided.
     """
 
     token_threshold: int = 100_000
-    summary_model: str = "claude-haiku-4-5-20251001"
+    summary_model: Optional[str] = None
     instructions: Optional[str] = None
 
     async def should_compact(self, chat: AgentlysBase) -> bool:
@@ -76,8 +81,6 @@ class TokenThresholdCompaction:
 
     async def compact(self, chat: AgentlysBase) -> None:
         """Summarize older messages and replace them with a compaction message."""
-        import anthropic as anthropic_sdk
-
         from agentlys.model import Message, MessagePart
 
         messages = chat.messages
@@ -95,46 +98,23 @@ class TokenThresholdCompaction:
 
         prompt = self.instructions or DEFAULT_COMPACTION_PROMPT
 
-        provider = chat.provider
-        # Reuse the provider's client so proxy auth / custom base_url work
-        if hasattr(provider, "client"):
-            client = provider.client
-        else:
-            client = anthropic_sdk.AsyncAnthropic()
-
         summary_messages = [
             {
                 "role": "user",
                 "content": (
-                    f"{prompt}\n\n"
-                    f"--- Conversation to summarize ---\n{conversation_str}"
+                    f"{prompt}\n\n--- Conversation to summarize ---\n{conversation_str}"
                 ),
             }
         ]
 
-        # Include the original system instruction for context
-        kwargs = {}
-        if chat.instruction:
-            kwargs["system"] = chat.instruction
-
-        # If the provider exposes auth headers (e.g. proxy), inject them
-        if hasattr(provider, "_get_auth_headers"):
-            kwargs["extra_headers"] = await provider._get_auth_headers()
-
-        response = await client.messages.create(
-            model=self.summary_model,
+        # The provider handles client shape, proxy auth and custom base_url
+        summary_text = await chat.provider.complete(
             messages=summary_messages,
+            # Include the original system instruction for context
+            system=chat.instruction,
+            model=self.summary_model,
             max_tokens=4096,
-            **kwargs,
         )
-
-        # Extract summary text (skip ThinkingBlocks when extended thinking is enabled)
-        text_block = next(
-            (block for block in response.content if block.type == "text"), None
-        )
-        if text_block is None:
-            raise RuntimeError("Compaction response contained no text block")
-        summary_text = text_block.text
 
         # Try to extract from <summary> tags if present
         match = re.search(r"<summary>(.*?)</summary>", summary_text, re.DOTALL)

--- a/src/agentlys/providers/anthropic.py
+++ b/src/agentlys/providers/anthropic.py
@@ -6,8 +6,6 @@ from agentlys.model import Message, MessagePart
 from agentlys.providers.base_provider import BaseProvider
 from agentlys.providers.utils import add_empty_function_result
 
-AGENTLYS_HOST = os.getenv("AGENTLYS_HOST")
-
 
 def part_to_anthropic_dict(part: MessagePart) -> dict:
     if part.type == "text":
@@ -110,10 +108,20 @@ DEFAULT_MAX_TOKENS = int(os.getenv("ANTHROPIC_MAX_TOKENS", "10000"))
 
 
 class AnthropicProvider(BaseProvider):
-    def __init__(self, chat: AgentlysBase, model: str, max_tokens: int | None = None):
+    def __init__(
+        self,
+        chat: AgentlysBase,
+        model: str,
+        max_tokens: int | None = None,
+        base_url: str | None = None,
+        api_key: str | None = None,
+    ):
         self.model = model
+        env_host = os.getenv("AGENTLYS_HOST")
         self.client = anthropic.AsyncAnthropic(
-            base_url=AGENTLYS_HOST if AGENTLYS_HOST else "https://api.anthropic.com",
+            base_url=base_url or env_host or "https://api.anthropic.com",
+            # None lets the SDK fall back to the ANTHROPIC_API_KEY env var
+            api_key=api_key or os.getenv("AGENTLYS_API_KEY"),
         )
         self.chat = chat
         self.max_tokens = DEFAULT_MAX_TOKENS if max_tokens is None else max_tokens

--- a/src/agentlys/providers/anthropic.py
+++ b/src/agentlys/providers/anthropic.py
@@ -374,6 +374,34 @@ class AnthropicProvider(BaseProvider):
         msg.usage = res_dict.get("usage")
         return msg
 
+    async def complete(
+        self,
+        messages: list[dict],
+        system: str | None = None,
+        model: str | None = None,
+        max_tokens: int = 4096,
+    ) -> str:
+        kwargs = {}
+        if system:
+            kwargs["system"] = system
+        # If the provider exposes auth headers (e.g. proxy), inject them
+        if hasattr(self, "_get_auth_headers"):
+            kwargs["extra_headers"] = await self._get_auth_headers()
+
+        response = await self.client.messages.create(
+            model=model or self.model,
+            messages=messages,
+            max_tokens=max_tokens,
+            **kwargs,
+        )
+        # Extract the text (skip ThinkingBlocks when extended thinking is enabled)
+        text_block = next(
+            (block for block in response.content if block.type == "text"), None
+        )
+        if text_block is None:
+            raise RuntimeError("Completion response contained no text block")
+        return text_block.text
+
     async def fetch_stream_async(self, **kwargs):
         """Stream response tokens from Anthropic.
 

--- a/src/agentlys/providers/base_provider.py
+++ b/src/agentlys/providers/base_provider.py
@@ -79,6 +79,25 @@ class BaseProvider(ABC):
         loop = get_event_loop_or_create()
         return loop.run_until_complete(self.fetch_async(**kwargs))
 
+    async def complete(
+        self,
+        messages: list[dict],
+        system: typing.Optional[str] = None,
+        model: typing.Optional[str] = None,
+        max_tokens: int = 4096,
+    ) -> str:
+        """One-shot text completion outside the conversation loop.
+
+        Used for auxiliary LLM calls such as compaction summaries.
+        ``messages`` are simple ``{"role", "content"}`` dicts; ``model``
+        defaults to the provider's configured model.  Returns the response
+        text.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support one-shot completions. "
+            "Please implement complete() to enable features like compaction."
+        )
+
     async def fetch_stream_async(self, **kwargs) -> typing.AsyncGenerator[dict, None]:
         """
         Async streaming version of fetch method.

--- a/src/agentlys/providers/default.py
+++ b/src/agentlys/providers/default.py
@@ -1,14 +1,12 @@
 import json
-import os
 
 from agentlys.base import AgentlysBase
 from agentlys.model import Message
 from agentlys.providers.openai import (
     OpenAIProvider,
+    create_openai_client,
     parts_to_openai_dict,
 )
-
-AGENTLYS_HOST = os.getenv("AGENTLYS_HOST")
 
 
 def message_to_openai_dict(message: Message) -> dict:
@@ -25,13 +23,13 @@ def message_to_openai_dict(message: Message) -> dict:
         res = {"role": message.role, "content": []}
         for part in message.parts:
             if part.type == "function_call" and message.role == "assistant":
-                res["tool_calls"] = [
+                res.setdefault("tool_calls", []).append(
                     {
                         "id": part.function_call_id,
                         "type": "function",
                         "function": parts_to_openai_dict(part),
                     }
-                ]
+                )
             elif part.type == "function_call" and message.role == "user":
                 # Workaround: If the user is triggering a function, we add it's name and arguments to the content
                 res["content"] = (
@@ -54,9 +52,13 @@ class DefaultProvider(OpenAIProvider):
     - Function call content is a string
     """
 
-    def __init__(self, chat: AgentlysBase, model: str, base_url: str = None):
-        from openai import OpenAI
-
+    def __init__(
+        self,
+        chat: AgentlysBase,
+        model: str,
+        base_url: str = None,
+        api_key: str = None,
+    ):
         self.chat = chat
         self.model = model
-        self.client = OpenAI(base_url=AGENTLYS_HOST)
+        self.client = create_openai_client(base_url=base_url, api_key=api_key)

--- a/src/agentlys/providers/default.py
+++ b/src/agentlys/providers/default.py
@@ -15,8 +15,9 @@ def message_to_openai_dict(message: Message) -> dict:
             "role": "tool",
             "tool_call_id": message.function_call_id,
             "content": message.content,
-            "name": message.name,
         }
+        if message.name:
+            res["name"] = message.name
     elif message.role == "system":
         res = {"role": message.role, "content": message.content}
     else:
@@ -49,8 +50,12 @@ def message_to_openai_dict(message: Message) -> dict:
 class DefaultProvider(OpenAIProvider):
     """Default provider is OpenAI with small changes
     - System messages are string only
-    - Function call content is a string
+    - Function result content is a string
+
+    Useful for OpenAI-compatible servers that reject list-of-parts content.
     """
+
+    message_transform = staticmethod(message_to_openai_dict)
 
     def __init__(
         self,

--- a/src/agentlys/providers/openai.py
+++ b/src/agentlys/providers/openai.py
@@ -123,6 +123,11 @@ def parts_to_openai_dict(part: MessagePart) -> dict:
                 "url": f"data:{part.image.format};base64,{part.image.to_base64()}"
             },
         }
+    elif part.type == "compaction":
+        return {
+            "type": "text",
+            "text": f"[Previous conversation summary]\n{part.content}",
+        }
 
     raise ValueError(f"Unknown part type: {part.type}")
 
@@ -201,6 +206,10 @@ def split_function_results(messages: list[Message]) -> list[Message]:
 
 
 class OpenAIProvider(BaseProvider):
+    # Wire-format hook: subclasses can swap the message serializer
+    # (see DefaultProvider's string-only variant).
+    message_transform = staticmethod(message_to_openai_dict)
+
     def __init__(
         self,
         chat: AgentlysBase,
@@ -215,7 +224,7 @@ class OpenAIProvider(BaseProvider):
     def _prepare_request_params(self, **kwargs):
         """Prepare messages, tools, and kwargs for an OpenAI-compatible request."""
         messages = self.prepare_messages(
-            transform_function=message_to_openai_dict,
+            transform_function=self.message_transform,
             transform_list_function=lambda x: split_function_results(
                 add_empty_function_result(return_image_as_user_message(x))
             ),
@@ -243,7 +252,7 @@ class OpenAIProvider(BaseProvider):
                     content=self.chat.initial_tools_states,
                 )
             )
-        messages = [message_to_openai_dict(sm) for sm in system_messages] + messages
+        messages = [self.message_transform(sm) for sm in system_messages] + messages
 
         if self.chat.use_tools_only and "tool_choice" not in kwargs:
             kwargs["tool_choice"] = "required"
@@ -288,6 +297,31 @@ class OpenAIProvider(BaseProvider):
             id=res.id,  # We use the response id as the message id
             usage=usage_to_dict(res.usage),
         )
+
+    async def complete(
+        self,
+        messages: list[dict],
+        system: typing.Optional[str] = None,
+        model: typing.Optional[str] = None,
+        max_tokens: int = 4096,
+    ) -> str:
+        if system:
+            messages = [{"role": "system", "content": system}] + messages
+        kwargs = {}
+        # If the provider exposes auth headers (e.g. proxy), inject them
+        if hasattr(self, "_get_auth_headers"):
+            kwargs["extra_headers"] = await self._get_auth_headers()
+
+        res = await self.client.chat.completions.create(
+            model=model or self.model,
+            messages=messages,
+            max_tokens=max_tokens,
+            **kwargs,
+        )
+        content = res.choices[0].message.content
+        if not content:
+            raise RuntimeError("Completion response contained no text")
+        return content
 
     async def fetch_stream_async(self, **kwargs):
         """Stream response tokens from any OpenAI-compatible chat completions API.

--- a/src/agentlys/providers/openai.py
+++ b/src/agentlys/providers/openai.py
@@ -7,7 +7,51 @@ from agentlys.model import Message, MessagePart
 from agentlys.providers.base_provider import BaseProvider
 from agentlys.providers.utils import FunctionCallParsingError, add_empty_function_result
 
-AGENTLYS_HOST = os.getenv("AGENTLYS_HOST")
+OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1"
+
+
+def create_openai_client(
+    base_url: typing.Optional[str] = None,
+    api_key: typing.Optional[str] = None,
+    host_suffix: str = "",
+):
+    """Build an AsyncOpenAI client for OpenAI or any OpenAI-compatible API.
+
+    Resolution order:
+    - base_url: explicit argument > AGENTLYS_HOST env (+ host_suffix) > OpenAI
+    - api_key: explicit argument > AGENTLYS_API_KEY env > OPENAI_API_KEY env
+
+    When a custom endpoint is configured but no API key is available, a
+    placeholder key is used so key-less OpenAI-compatible servers
+    (Ollama, vLLM, LiteLLM, ...) work out of the box — the SDK refuses to
+    build a client without a key.
+    """
+    from openai import AsyncOpenAI
+
+    env_host = os.getenv("AGENTLYS_HOST")
+    resolved_base_url = base_url or (f"{env_host}{host_suffix}" if env_host else None)
+    resolved_api_key = api_key or os.getenv("AGENTLYS_API_KEY")
+    if (
+        resolved_api_key is None
+        and resolved_base_url is not None
+        and not os.getenv("OPENAI_API_KEY")
+    ):
+        resolved_api_key = "not-needed"
+
+    return AsyncOpenAI(
+        base_url=resolved_base_url or OPENAI_DEFAULT_BASE_URL,
+        api_key=resolved_api_key,
+    )
+
+
+def usage_to_dict(usage) -> typing.Optional[dict]:
+    """Normalize OpenAI usage to the input/output_tokens naming used by Message."""
+    if usage is None:
+        return None
+    return {
+        "input_tokens": usage.prompt_tokens,
+        "output_tokens": usage.completion_tokens,
+    }
 
 
 def from_openai_object(
@@ -15,36 +59,38 @@ def from_openai_object(
     content: str,
     tool_calls: typing.Optional[list] = None,
     id: typing.Optional[str] = None,
+    usage: typing.Optional[dict] = None,
 ):
     # We need to unquote the arguments
 
-    function_call_dict = None
-    function_call_id = None
-    if tool_calls:
-        first_tool_call_function = next(
-            (t for t in tool_calls if t.type == "function"), None
-        )
-        if first_tool_call_function is None:
+    parts = []
+    if content:
+        parts.append(MessagePart(type="text", content=content))
+
+    for tool_call in tool_calls or []:
+        if tool_call.type != "function":
             raise ValueError(
                 "We don't support tool calls with type other than function"
             )
-        function_call = first_tool_call_function.function
-        function_call_id = first_tool_call_function.id
+        function_call = tool_call.function
         try:
-            function_call_dict = {
-                "name": function_call.name,
-                "arguments": json.loads(function_call.arguments),
-            }
+            arguments = json.loads(function_call.arguments or "{}")
         except json.decoder.JSONDecodeError:
             raise FunctionCallParsingError(id, function_call)
+        parts.append(
+            MessagePart(
+                type="function_call",
+                function_call={
+                    "name": function_call.name,
+                    "arguments": arguments,
+                },
+                function_call_id=tool_call.id,
+            )
+        )
 
-    return Message(
-        role=role,
-        content=content,
-        function_call=function_call_dict,
-        id=id,
-        function_call_id=function_call_id,
-    )
+    if parts:
+        return Message(role=role, parts=parts, id=id, usage=usage)
+    return Message(role=role, content=content, id=id, usage=usage)
 
 
 def parts_to_openai_dict(part: MessagePart) -> dict:
@@ -87,19 +133,20 @@ def message_to_openai_dict(message: Message) -> dict:
             "role": "tool",
             "tool_call_id": message.function_call_id,
             "content": [parts_to_openai_dict(part) for part in message.parts],
-            "name": message.name,
         }
+        if message.name:
+            res["name"] = message.name
     else:
         res = {"role": message.role, "content": []}
         for part in message.parts:
             if part.type == "function_call" and message.role == "assistant":
-                res["tool_calls"] = [
+                res.setdefault("tool_calls", []).append(
                     {
                         "id": part.function_call_id,
                         "type": "function",
                         "function": parts_to_openai_dict(part),
                     }
-                ]
+                )
             elif part.type == "function_call" and message.role == "user":
                 # Workaround: If the user is triggering a function, we add it's name and arguments to the content
                 res["content"] = (
@@ -127,22 +174,50 @@ def return_image_as_user_message(messages: list[Message]) -> list[Message]:
     return messages
 
 
-class OpenAIProvider(BaseProvider):
-    def __init__(self, chat: AgentlysBase, model: str, base_url: str = None):
-        from openai import OpenAI
+def split_function_results(messages: list[Message]) -> list[Message]:
+    """Split parallel tool results into one function message per tool call.
 
+    OpenAI-compatible APIs require one ``role="tool"`` message per
+    ``tool_call_id``, while agentlys combines parallel tool results into a
+    single function message (the Anthropic convention).
+    """
+    result = []
+    for message in messages:
+        call_ids = {
+            part.function_call_id
+            for part in message.parts
+            if part.function_call_id is not None
+        }
+        if message.role != "function" or len(call_ids) <= 1:
+            result.append(message)
+            continue
+        # Preserve part order while grouping by function_call_id
+        groups: dict[str, list[MessagePart]] = {}
+        for part in message.parts:
+            groups.setdefault(part.function_call_id, []).append(part)
+        for parts in groups.values():
+            result.append(Message(role="function", name=message.name, parts=parts))
+    return result
+
+
+class OpenAIProvider(BaseProvider):
+    def __init__(
+        self,
+        chat: AgentlysBase,
+        model: str,
+        base_url: str = None,
+        api_key: str = None,
+    ):
         self.chat = chat
         self.model = model
-        # Possibly set up openai.api_key, base_url, etc.
-        self.client = OpenAI(
-            base_url=(AGENTLYS_HOST if AGENTLYS_HOST else "https://api.openai.com/v1"),
-        )
+        self.client = create_openai_client(base_url=base_url, api_key=api_key)
 
-    async def fetch_async(self, **kwargs) -> Message:
+    def _prepare_request_params(self, **kwargs):
+        """Prepare messages, tools, and kwargs for an OpenAI-compatible request."""
         messages = self.prepare_messages(
             transform_function=message_to_openai_dict,
-            transform_list_function=lambda x: add_empty_function_result(
-                return_image_as_user_message(x)
+            transform_list_function=lambda x: split_function_results(
+                add_empty_function_result(return_image_as_user_message(x))
             ),
         )
 
@@ -173,8 +248,8 @@ class OpenAIProvider(BaseProvider):
         if self.chat.use_tools_only and "tool_choice" not in kwargs:
             kwargs["tool_choice"] = "required"
 
+        tools = []
         if self.chat.functions_schema:
-            tools = []
             for tool_schema in self.chat.functions_schema:
                 # Strip defer_loading from the function schema before sending
                 clean_schema = {
@@ -187,14 +262,21 @@ class OpenAIProvider(BaseProvider):
                 if tool_schema.get("defer_loading"):
                     tool_def["defer_loading"] = True
                 tools.append(tool_def)
-            res = self.client.chat.completions.create(
+
+        return messages, tools, kwargs
+
+    async def fetch_async(self, **kwargs) -> Message:
+        messages, tools, kwargs = self._prepare_request_params(**kwargs)
+
+        if tools:
+            res = await self.client.chat.completions.create(
                 model=self.model,
                 messages=messages,
                 tools=tools,
                 **kwargs,
             )
         else:
-            res = self.client.chat.completions.create(
+            res = await self.client.chat.completions.create(
                 model=self.model, messages=messages, **kwargs
             )
 
@@ -204,4 +286,82 @@ class OpenAIProvider(BaseProvider):
             content=message.content,
             tool_calls=message.tool_calls,
             id=res.id,  # We use the response id as the message id
+            usage=usage_to_dict(res.usage),
         )
+
+    async def fetch_stream_async(self, **kwargs):
+        """Stream response tokens from any OpenAI-compatible chat completions API.
+
+        Yields text chunks as they arrive, then the final Message
+        (with potential tool calls) after streaming completes.
+        """
+        messages, tools, kwargs = self._prepare_request_params(**kwargs)
+        if tools:
+            kwargs["tools"] = tools
+
+        stream = await self.client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+            stream=True,
+            **kwargs,
+        )
+
+        response_id = None
+        role = "assistant"
+        content_chunks: list[str] = []
+        # index -> accumulated tool call (OpenAI streams tool calls in fragments)
+        tool_calls: dict[int, dict] = {}
+        usage = None
+
+        async for chunk in stream:
+            if response_id is None:
+                response_id = chunk.id
+            if getattr(chunk, "usage", None):
+                usage = chunk.usage
+            if not chunk.choices:
+                continue
+            delta = chunk.choices[0].delta
+            if delta is None:
+                continue
+            if delta.role:
+                role = delta.role
+            if delta.content:
+                content_chunks.append(delta.content)
+                yield {"type": "text", "content": delta.content}
+            for tool_call in delta.tool_calls or []:
+                entry = tool_calls.setdefault(
+                    tool_call.index, {"id": None, "name": "", "arguments": ""}
+                )
+                if tool_call.id:
+                    entry["id"] = tool_call.id
+                if tool_call.function:
+                    if tool_call.function.name:
+                        entry["name"] += tool_call.function.name
+                    if tool_call.function.arguments:
+                        entry["arguments"] += tool_call.function.arguments
+
+        parts = []
+        content = "".join(content_chunks)
+        if content:
+            parts.append(MessagePart(type="text", content=content))
+        for index in sorted(tool_calls):
+            entry = tool_calls[index]
+            try:
+                arguments = json.loads(entry["arguments"] or "{}")
+            except json.decoder.JSONDecodeError:
+                raise FunctionCallParsingError(response_id, entry)
+            parts.append(
+                MessagePart(
+                    type="function_call",
+                    function_call={
+                        "name": entry["name"],
+                        "arguments": arguments,
+                    },
+                    function_call_id=entry["id"],
+                )
+            )
+
+        final_message = Message(
+            role=role, parts=parts, id=response_id, usage=usage_to_dict(usage)
+        )
+        yield {"type": "message", "message": final_message}

--- a/src/agentlys/providers/openai_function_legacy.py
+++ b/src/agentlys/providers/openai_function_legacy.py
@@ -58,6 +58,11 @@ def parts_to_openai_dict(part: MessagePart) -> dict:
                 "url": f"data:{part.image.format};base64,{part.image.to_base64()}"
             },
         }
+    elif part.type == "compaction":
+        return {
+            "type": "text",
+            "text": f"[Previous conversation summary]\n{part.content}",
+        }
 
     raise ValueError(f"Unknown part type: {part.type}")
 

--- a/src/agentlys/providers/openai_function_legacy.py
+++ b/src/agentlys/providers/openai_function_legacy.py
@@ -1,13 +1,11 @@
 import json
-import os
 import typing
 
 from agentlys.base import AgentlysBase
 from agentlys.model import Message, MessagePart
 from agentlys.providers.base_provider import BaseProvider
+from agentlys.providers.openai import create_openai_client
 from agentlys.providers.utils import FunctionCallParsingError
-
-AGENTLYS_HOST = os.getenv("AGENTLYS_HOST")
 
 
 def from_openai_object(
@@ -97,16 +95,17 @@ def message_to_openai_dict(message: Message) -> dict:
 
 
 class OpenAIProviderFunctionLegacy(BaseProvider):
-    def __init__(self, chat: AgentlysBase, model: str, base_url: str = None):
-        from openai import OpenAI
-
+    def __init__(
+        self,
+        chat: AgentlysBase,
+        model: str,
+        base_url: str = None,
+        api_key: str = None,
+    ):
         self.chat = chat
         self.model = model
-        # Possibly set up openai.api_key, base_url, etc.
-        self.client = OpenAI(
-            base_url=(
-                f"{AGENTLYS_HOST}/v1" if AGENTLYS_HOST else "https://api.openai.com/v1"
-            ),
+        self.client = create_openai_client(
+            base_url=base_url, api_key=api_key, host_suffix="/v1"
         )
 
     async def fetch_async(self, **kwargs) -> Message:
@@ -138,14 +137,14 @@ class OpenAIProviderFunctionLegacy(BaseProvider):
         messages = [message_to_openai_dict(sm) for sm in system_messages] + messages
 
         if self.chat.functions_schema:
-            res = self.client.chat.completions.create(
+            res = await self.client.chat.completions.create(
                 model=self.model,
                 messages=messages,
                 functions=self.chat.functions_schema,
                 **kwargs,
             )
         else:
-            res = self.client.chat.completions.create(
+            res = await self.client.chat.completions.create(
                 model=self.model, messages=messages, **kwargs
             )
 

--- a/src/agentlys/providers/openai_function_shim.py
+++ b/src/agentlys/providers/openai_function_shim.py
@@ -124,7 +124,7 @@ class OpenAIProviderFunctionShim(OpenAIProvider):
             messages = [message_to_openai_dict(system_msg)] + messages
 
         # Make the request WITHOUT 'functions='
-        res = self.client.chat.completions.create(
+        res = await self.client.chat.completions.create(
             model=self.model,
             messages=messages,
         )

--- a/src/agentlys/providers/openai_function_shim.py
+++ b/src/agentlys/providers/openai_function_shim.py
@@ -73,9 +73,6 @@ def message_to_openai_dict(message: Message) -> dict:
 
 
 class OpenAIProviderFunctionShim(OpenAIProvider):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     async def fetch_async(self):
         """
         Calls the OpenAI ChatCompletion endpoint using ONLY text-based instructions for function usage.

--- a/src/agentlys/providers/utils.py
+++ b/src/agentlys/providers/utils.py
@@ -11,7 +11,7 @@ class FunctionCallParsingError(Exception):
         self.function_call = function_call
 
     def __str__(self):
-        return f"Invalid function_call: {self.obj.function_call}"
+        return f"Invalid function_call: {self.function_call}"
 
 
 # TODO: should probably exploit default model from provider

--- a/src/agentlys/providers/utils.py
+++ b/src/agentlys/providers/utils.py
@@ -20,18 +20,32 @@ def get_provider_and_model(  # TODO: get_provider_and_model ?
     chat,
     provider_name: Union[str, Type[BaseProvider]] = None,
     model: str = None,
+    base_url: str = None,
+    api_key: str = None,
 ) -> list[str, BaseProvider]:  # TODO: rename
     """
     Returns the correct LLM provider based on a string or env vars.
+
+    ``base_url`` and ``api_key`` let you target any OpenAI-compatible API
+    (Ollama, vLLM, LiteLLM, OpenRouter, Azure OpenAI, ...) or a custom
+    Anthropic-compatible endpoint.
     """
 
     if not provider_name:
-        provider_name = os.getenv("AGENTLYS_HOST", "openai")
+        provider_name = os.getenv("AGENTLYS_PROVIDER", "openai")
+
+    # Only forward what was explicitly provided so custom provider classes
+    # that don't accept base_url/api_key keep working.
+    client_kwargs = {}
+    if base_url is not None:
+        client_kwargs["base_url"] = base_url
+    if api_key is not None:
+        client_kwargs["api_key"] = api_key
 
     if isinstance(provider_name, type) and issubclass(provider_name, BaseProvider):
         # Supports custom provider
         Provider = provider_name
-        return Provider(chat, model=model), model
+        return Provider(chat, model=model, **client_kwargs), model
     elif isinstance(provider_name, APIProvider):
         provider_key = provider_name
     elif isinstance(provider_name, str):
@@ -47,19 +61,19 @@ def get_provider_and_model(  # TODO: get_provider_and_model ?
 
         if not model:
             model = os.getenv("AGENTLYS_MODEL", "gpt-4o")
-        return OpenAIProvider(chat, model=model), model
+        return OpenAIProvider(chat, model=model, **client_kwargs), model
     elif provider_key == APIProvider.ANTHROPIC:
         from agentlys.providers.anthropic import AnthropicProvider
 
         if not model:
             model = os.getenv("AGENTLYS_MODEL", "claude-3-7-sonnet-latest")
-        return AnthropicProvider(chat, model=model), model
+        return AnthropicProvider(chat, model=model, **client_kwargs), model
     elif provider_key == APIProvider.OPENAI_FUNCTION_SHIM:
         from agentlys.providers.openai_function_shim import OpenAIProviderFunctionShim
 
         if not model:
             model = os.getenv("AGENTLYS_MODEL", "o1-preview")
-        return OpenAIProviderFunctionShim(chat, model=model), model
+        return OpenAIProviderFunctionShim(chat, model=model, **client_kwargs), model
     elif provider_key == APIProvider.OPENAI_FUNCTION_LEGACY:
         from agentlys.providers.openai_function_legacy import (
             OpenAIProviderFunctionLegacy,
@@ -67,13 +81,13 @@ def get_provider_and_model(  # TODO: get_provider_and_model ?
 
         if not model:
             model = os.getenv("AGENTLYS_MODEL", "gpt-4o")
-        return OpenAIProviderFunctionLegacy(chat, model=model), model
+        return OpenAIProviderFunctionLegacy(chat, model=model, **client_kwargs), model
     elif provider_key == APIProvider.DEFAULT:
         from agentlys.providers.default import DefaultProvider
 
         if not model:
             raise ValueError("Default provider requires a model")
-        return DefaultProvider(chat, model=model), model
+        return DefaultProvider(chat, model=model, **client_kwargs), model
     else:
         raise ValueError(f"Provider {provider_key} is not supported")
 

--- a/tests/cassettes/test_call_async/test_run_conversation_async_multiple_turns_openai.yaml
+++ b/tests/cassettes/test_call_async/test_run_conversation_async_multiple_turns_openai.yaml
@@ -1,9 +1,6 @@
 interactions:
 - request:
-    body: '{"messages":[{"role":"user","content":[{"type":"text","text":"First calculate
-      1 + 2, then process the result"}]}],"model":"gpt-4o","tools":[{"type":"function","function":{"name":"async_calculator","description":null,"parameters":{"properties":{"kwargs":{"title":"Kwargs"}},"required":["kwargs"],"title":"Input
-      for `async_calculator`","type":"object"}}},{"type":"function","function":{"name":"async_data_processor","description":null,"parameters":{"properties":{"kwargs":{"title":"Kwargs"}},"required":["kwargs"],"title":"Input
-      for `async_data_processor`","type":"object"}}}]}'
+    body: '{"messages":[{"role":"user","content":[{"type":"text","text":"First calculate 1 + 2, then process the result"}]}],"model":"gpt-4o","tools":[{"type":"function","function":{"name":"async_calculator","description":null,"parameters":{"properties":{"kwargs":{"title":"Kwargs"}},"required":["kwargs"],"title":"Input for `async_calculator`","type":"object"}}},{"type":"function","function":{"name":"async_data_processor","description":null,"parameters":{"properties":{"kwargs":{"title":"Kwargs"}},"required":["kwargs"],"title":"Input for `async_data_processor`","type":"object"}}}]}'
     headers:
       content-type:
       - application/json
@@ -15,25 +12,7 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: "{\n  \"id\": \"chatcmpl-BMUkqXXfSJ24nN6JvGXc2OB9OQVfF\",\n  \"object\":
-        \"chat.completion\",\n  \"created\": 1744701136,\n  \"model\": \"gpt-4o-2024-08-06\",\n
-        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
-        \"assistant\",\n        \"content\": null,\n        \"tool_calls\": [\n          {\n
-        \           \"id\": \"call_Fn4w2HHboFGyvRqtGBXKexVS\",\n            \"type\":
-        \"function\",\n            \"function\": {\n              \"name\": \"async_calculator\",\n
-        \             \"arguments\": \"{\\\"kwargs\\\": {\\\"expression\\\": \\\"1
-        + 2\\\"}}\"\n            }\n          },\n          {\n            \"id\":
-        \"call_p8Rwq1zadLgLUQRY9Wpn427k\",\n            \"type\": \"function\",\n
-        \           \"function\": {\n              \"name\": \"async_data_processor\",\n
-        \             \"arguments\": \"{\\\"kwargs\\\": {\\\"data\\\": 3}}\"\n            }\n
-        \         }\n        ],\n        \"refusal\": null,\n        \"annotations\":
-        []\n      },\n      \"logprobs\": null,\n      \"finish_reason\": \"tool_calls\"\n
-        \   }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 89,\n    \"completion_tokens\":
-        55,\n    \"total_tokens\": 144,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\":
-        0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
-        {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\":
-        0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\":
-        \"default\",\n  \"system_fingerprint\": \"fp_22890b9c0a\"\n}\n"
+      string: "{\n  \"id\": \"chatcmpl-BMUkqXXfSJ24nN6JvGXc2OB9OQVfF\",\n  \"object\": \"chat.completion\",\n  \"created\": 1744701136,\n  \"model\": \"gpt-4o-2024-08-06\",\n  \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\": \"assistant\",\n        \"content\": null,\n        \"tool_calls\": [\n          {\n            \"id\": \"call_Fn4w2HHboFGyvRqtGBXKexVS\",\n            \"type\": \"function\",\n            \"function\": {\n              \"name\": \"async_calculator\",\n              \"arguments\": \"{\\\"kwargs\\\": {\\\"expression\\\": \\\"1 + 2\\\"}}\"\n            }\n          },\n          {\n            \"id\": \"call_p8Rwq1zadLgLUQRY9Wpn427k\",\n            \"type\": \"function\",\n            \"function\": {\n              \"name\": \"async_data_processor\",\n              \"arguments\": \"{\\\"kwargs\\\": {\\\"data\\\": 3}}\"\n            }\n          }\n        ],\n        \"refusal\": null,\n        \"annotations\": []\n      },\n      \"logprobs\": null,\n      \"finish_reason\": \"tool_calls\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 89,\n    \"completion_tokens\": 55,\n    \"total_tokens\": 144,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\": 0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\": {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\": 0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\": \"default\",\n  \"system_fingerprint\": \"fp_22890b9c0a\"\n}\n"
     headers:
       Connection:
       - keep-alive
@@ -55,11 +34,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"messages":[{"role":"user","content":[{"type":"text","text":"First calculate
-      1 + 2, then process the result"}]},{"role":"assistant","content":null,"tool_calls":[{"id":"call_Fn4w2HHboFGyvRqtGBXKexVS","type":"function","function":{"name":"async_calculator","arguments":"{\"kwargs\":
-      {\"expression\": \"1 + 2\"}}"}}]},{"role":"tool","tool_call_id":"call_Fn4w2HHboFGyvRqtGBXKexVS","content":[{"type":"text","text":"0"}],"name":"async_calculator"}],"model":"gpt-4o","tools":[{"type":"function","function":{"name":"async_calculator","description":null,"parameters":{"properties":{"kwargs":{"title":"Kwargs"}},"required":["kwargs"],"title":"Input
-      for `async_calculator`","type":"object"}}},{"type":"function","function":{"name":"async_data_processor","description":null,"parameters":{"properties":{"kwargs":{"title":"Kwargs"}},"required":["kwargs"],"title":"Input
-      for `async_data_processor`","type":"object"}}}]}'
+    body: '{"messages": [{"role": "user", "content": [{"type": "text", "text": "First calculate 1 + 2, then process the result"}]}, {"role": "assistant", "content": null, "tool_calls": [{"id": "call_Fn4w2HHboFGyvRqtGBXKexVS", "type": "function", "function": {"name": "async_calculator", "arguments": "{\"kwargs\": {\"expression\": \"1 + 2\"}}"}}, {"id": "call_p8Rwq1zadLgLUQRY9Wpn427k", "type": "function", "function": {"name": "async_data_processor", "arguments": "{\"kwargs\": {\"data\": 3}}"}}]}, {"role": "tool", "tool_call_id": "call_Fn4w2HHboFGyvRqtGBXKexVS", "content": [{"type": "text", "text": "0"}]}, {"role": "tool", "tool_call_id": "call_p8Rwq1zadLgLUQRY9Wpn427k", "content": [{"type": "text", "text": "{\"result\": \"processed data\"}"}]}], "model": "gpt-4o", "tools": [{"type": "function", "function": {"name": "async_calculator", "description": null, "parameters": {"properties": {"kwargs": {"title": "Kwargs"}}, "required": ["kwargs"], "title": "Input for `async_calculator`", "type": "object"}}}, {"type": "function", "function": {"name": "async_data_processor", "description": null, "parameters": {"properties": {"kwargs": {"title": "Kwargs"}}, "required": ["kwargs"], "title": "Input for `async_data_processor`", "type": "object"}}}]}'
     headers:
       content-type:
       - application/json
@@ -71,72 +46,7 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: "{\n  \"id\": \"chatcmpl-BMUkrKKeUDcggk2OdK1ukKr2gISvn\",\n  \"object\":
-        \"chat.completion\",\n  \"created\": 1744701137,\n  \"model\": \"gpt-4o-2024-08-06\",\n
-        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
-        \"assistant\",\n        \"content\": null,\n        \"tool_calls\": [\n          {\n
-        \           \"id\": \"call_P58AIigJwclXwTY1NfPTZF2c\",\n            \"type\":
-        \"function\",\n            \"function\": {\n              \"name\": \"async_data_processor\",\n
-        \             \"arguments\": \"{\\\"kwargs\\\":{\\\"data\\\":3}}\"\n            }\n
-        \         }\n        ],\n        \"refusal\": null,\n        \"annotations\":
-        []\n      },\n      \"logprobs\": null,\n      \"finish_reason\": \"tool_calls\"\n
-        \   }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 119,\n    \"completion_tokens\":
-        18,\n    \"total_tokens\": 137,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\":
-        0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
-        {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\":
-        0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\":
-        \"default\",\n  \"system_fingerprint\": \"fp_22890b9c0a\"\n}\n"
-    headers:
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - ''
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      access-control-expose-headers:
-      - X-Request-ID
-      alt-svc:
-      - h3=":443"; ma=86400
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains; preload
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"messages":[{"role":"user","content":[{"type":"text","text":"First calculate
-      1 + 2, then process the result"}]},{"role":"assistant","content":null,"tool_calls":[{"id":"call_Fn4w2HHboFGyvRqtGBXKexVS","type":"function","function":{"name":"async_calculator","arguments":"{\"kwargs\":
-      {\"expression\": \"1 + 2\"}}"}}]},{"role":"tool","tool_call_id":"call_Fn4w2HHboFGyvRqtGBXKexVS","content":[{"type":"text","text":"0"}],"name":"async_calculator"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_P58AIigJwclXwTY1NfPTZF2c","type":"function","function":{"name":"async_data_processor","arguments":"{\"kwargs\":
-      {\"data\": 3}}"}}]},{"role":"tool","tool_call_id":"call_P58AIigJwclXwTY1NfPTZF2c","content":[{"type":"text","text":"{\"result\":
-      \"processed data\"}"}],"name":"async_data_processor"}],"model":"gpt-4o","tools":[{"type":"function","function":{"name":"async_calculator","description":null,"parameters":{"properties":{"kwargs":{"title":"Kwargs"}},"required":["kwargs"],"title":"Input
-      for `async_calculator`","type":"object"}}},{"type":"function","function":{"name":"async_data_processor","description":null,"parameters":{"properties":{"kwargs":{"title":"Kwargs"}},"required":["kwargs"],"title":"Input
-      for `async_data_processor`","type":"object"}}}]}'
-    headers:
-      content-type:
-      - application/json
-      host:
-      - api.openai.com
-      x-stainless-read-timeout:
-      - '600'
-    method: POST
-    uri: https://api.openai.com/v1/chat/completions
-  response:
-    body:
-      string: "{\n  \"id\": \"chatcmpl-BMUksOc4vr7hvZCpUN5LRn9OX3e7m\",\n  \"object\":
-        \"chat.completion\",\n  \"created\": 1744701138,\n  \"model\": \"gpt-4o-2024-08-06\",\n
-        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
-        \"assistant\",\n        \"content\": \"The sum of 1 + 2 is 3, and after processing
-        the result, you get \\\"processed data.\\\"\",\n        \"refusal\": null,\n
-        \       \"annotations\": []\n      },\n      \"logprobs\": null,\n      \"finish_reason\":
-        \"stop\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 152,\n    \"completion_tokens\":
-        26,\n    \"total_tokens\": 178,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\":
-        0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
-        {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\":
-        0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\":
-        \"default\",\n  \"system_fingerprint\": \"fp_22890b9c0a\"\n}\n"
+      string: "{\n  \"id\": \"chatcmpl-BMUksOc4vr7hvZCpUN5LRn9OX3e7m\",\n  \"object\": \"chat.completion\",\n  \"created\": 1744701138,\n  \"model\": \"gpt-4o-2024-08-06\",\n  \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\": \"assistant\",\n        \"content\": \"The sum of 1 + 2 is 3, and after processing the result, you get \\\"processed data.\\\"\",\n        \"refusal\": null,\n        \"annotations\": []\n      },\n      \"logprobs\": null,\n      \"finish_reason\": \"stop\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 152,\n    \"completion_tokens\": 26,\n    \"total_tokens\": 178,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\": 0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\": {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\": 0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\": \"default\",\n  \"system_fingerprint\": \"fp_22890b9c0a\"\n}\n"
     headers:
       Connection:
       - keep-alive

--- a/tests/mcp_clients/cassettes/test_mcp/test_mcp_openai.yaml
+++ b/tests/mcp_clients/cassettes/test_mcp/test_mcp_openai.yaml
@@ -1,9 +1,6 @@
 interactions:
 - request:
-    body: '{"messages":[{"role":"user","content":[{"type":"text","text":"Use calculator
-      to add 1 and 2"}]}],"model":"gpt-4o","tools":[{"type":"function","function":{"name":"add","description":"Add
-      two numbers","parameters":{"properties":{"a":{"title":"A","type":"integer"},"b":{"title":"B","type":"integer"}},"required":["a","b"],"title":"addArguments","type":"object"}}},{"type":"function","function":{"name":"files__","description":"uri:files://","parameters":{"properties":{},"required":[],"type":"object"}}},{"type":"function","function":{"name":"files__file_name","description":"uri:files://{file_name}\nGet
-      a file","parameters":{"properties":{"file_name":{"title":"file_name","type":"string"}},"required":["file_name"],"type":"object"}}}]}'
+    body: '{"messages":[{"role":"user","content":[{"type":"text","text":"Use calculator to add 1 and 2"}]}],"model":"gpt-4o","tools":[{"type":"function","function":{"name":"add","description":"Add two numbers","parameters":{"properties":{"a":{"title":"A","type":"integer"},"b":{"title":"B","type":"integer"}},"required":["a","b"],"title":"addArguments","type":"object"}}},{"type":"function","function":{"name":"files__","description":"uri:files://","parameters":{"properties":{},"required":[],"type":"object"}}},{"type":"function","function":{"name":"files__file_name","description":"uri:files://{file_name}\nGet a file","parameters":{"properties":{"file_name":{"title":"file_name","type":"string"}},"required":["file_name"],"type":"object"}}}]}'
     headers:
       content-type:
       - application/json
@@ -15,21 +12,7 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: "{\n  \"id\": \"chatcmpl-BMUlN2d196fbLKKAJIn2GzqHckS5t\",\n  \"object\":
-        \"chat.completion\",\n  \"created\": 1744701169,\n  \"model\": \"gpt-4o-2024-08-06\",\n
-        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
-        \"assistant\",\n        \"content\": null,\n        \"tool_calls\": [\n          {\n
-        \           \"id\": \"call_rPuDEhw3SduaxpPsl4qUNefF\",\n            \"type\":
-        \"function\",\n            \"function\": {\n              \"name\": \"add\",\n
-        \             \"arguments\": \"{\\\"a\\\":1,\\\"b\\\":2}\"\n            }\n
-        \         }\n        ],\n        \"refusal\": null,\n        \"annotations\":
-        []\n      },\n      \"logprobs\": null,\n      \"finish_reason\": \"tool_calls\"\n
-        \   }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 108,\n    \"completion_tokens\":
-        18,\n    \"total_tokens\": 126,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\":
-        0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
-        {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\":
-        0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\":
-        \"default\",\n  \"system_fingerprint\": \"fp_a6dfaf2bcf\"\n}\n"
+      string: "{\n  \"id\": \"chatcmpl-BMUlN2d196fbLKKAJIn2GzqHckS5t\",\n  \"object\": \"chat.completion\",\n  \"created\": 1744701169,\n  \"model\": \"gpt-4o-2024-08-06\",\n  \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\": \"assistant\",\n        \"content\": null,\n        \"tool_calls\": [\n          {\n            \"id\": \"call_rPuDEhw3SduaxpPsl4qUNefF\",\n            \"type\": \"function\",\n            \"function\": {\n              \"name\": \"add\",\n              \"arguments\": \"{\\\"a\\\":1,\\\"b\\\":2}\"\n            }\n          }\n        ],\n        \"refusal\": null,\n        \"annotations\": []\n      },\n      \"logprobs\": null,\n      \"finish_reason\": \"tool_calls\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 108,\n    \"completion_tokens\": 18,\n    \"total_tokens\": 126,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\": 0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\": {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\": 0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\": \"default\",\n  \"system_fingerprint\": \"fp_a6dfaf2bcf\"\n}\n"
     headers:
       Connection:
       - keep-alive
@@ -51,11 +34,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"messages":[{"role":"user","content":[{"type":"text","text":"Use calculator
-      to add 1 and 2"}]},{"role":"assistant","content":null,"tool_calls":[{"id":"call_rPuDEhw3SduaxpPsl4qUNefF","type":"function","function":{"name":"add","arguments":"{\"a\":
-      1, \"b\": 2}"}}]},{"role":"tool","tool_call_id":"call_rPuDEhw3SduaxpPsl4qUNefF","content":[{"type":"text","text":"3"}],"name":"add"}],"model":"gpt-4o","tools":[{"type":"function","function":{"name":"add","description":"Add
-      two numbers","parameters":{"properties":{"a":{"title":"A","type":"integer"},"b":{"title":"B","type":"integer"}},"required":["a","b"],"title":"addArguments","type":"object"}}},{"type":"function","function":{"name":"files__","description":"uri:files://","parameters":{"properties":{},"required":[],"type":"object"}}},{"type":"function","function":{"name":"files__file_name","description":"uri:files://{file_name}\nGet
-      a file","parameters":{"properties":{"file_name":{"title":"file_name","type":"string"}},"required":["file_name"],"type":"object"}}}]}'
+    body: '{"messages":[{"role":"user","content":[{"type":"text","text":"Use calculator to add 1 and 2"}]},{"role":"assistant","content":null,"tool_calls":[{"id":"call_rPuDEhw3SduaxpPsl4qUNefF","type":"function","function":{"name":"add","arguments":"{\"a\": 1, \"b\": 2}"}}]},{"role":"tool","tool_call_id":"call_rPuDEhw3SduaxpPsl4qUNefF","content":[{"type":"text","text":"3"}],"name":"add"}],"model":"gpt-4o","tools":[{"type":"function","function":{"name":"add","description":"Add two numbers","parameters":{"properties":{"a":{"title":"A","type":"integer"},"b":{"title":"B","type":"integer"}},"required":["a","b"],"title":"addArguments","type":"object"}}},{"type":"function","function":{"name":"files__","description":"uri:files://","parameters":{"properties":{},"required":[],"type":"object"}}},{"type":"function","function":{"name":"files__file_name","description":"uri:files://{file_name}\nGet a file","parameters":{"properties":{"file_name":{"title":"file_name","type":"string"}},"required":["file_name"],"type":"object"}}}]}'
     headers:
       content-type:
       - application/json
@@ -67,17 +46,7 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: "{\n  \"id\": \"chatcmpl-BMUlOYdb303gsH1ijfptNGFhS85Rm\",\n  \"object\":
-        \"chat.completion\",\n  \"created\": 1744701170,\n  \"model\": \"gpt-4o-2024-08-06\",\n
-        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
-        \"assistant\",\n        \"content\": \"The sum of 1 and 2 is 3.\",\n        \"refusal\":
-        null,\n        \"annotations\": []\n      },\n      \"logprobs\": null,\n
-        \     \"finish_reason\": \"stop\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\":
-        133,\n    \"completion_tokens\": 14,\n    \"total_tokens\": 147,\n    \"prompt_tokens_details\":
-        {\n      \"cached_tokens\": 0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
-        {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\":
-        0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\":
-        \"default\",\n  \"system_fingerprint\": \"fp_a6dfaf2bcf\"\n}\n"
+      string: "{\n  \"id\": \"chatcmpl-BMUlOYdb303gsH1ijfptNGFhS85Rm\",\n  \"object\": \"chat.completion\",\n  \"created\": 1744701170,\n  \"model\": \"gpt-4o-2024-08-06\",\n  \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\": \"assistant\",\n        \"content\": \"The sum of 1 and 2 is 3.\",\n        \"refusal\": null,\n        \"annotations\": []\n      },\n      \"logprobs\": null,\n      \"finish_reason\": \"stop\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 133,\n    \"completion_tokens\": 14,\n    \"total_tokens\": 147,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\": 0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\": {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\": 0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\": \"default\",\n  \"system_fingerprint\": \"fp_a6dfaf2bcf\"\n}\n"
     headers:
       Connection:
       - keep-alive
@@ -99,13 +68,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"messages":[{"role":"user","content":[{"type":"text","text":"Use calculator
-      to add 1 and 2"}]},{"role":"assistant","content":null,"tool_calls":[{"id":"call_rPuDEhw3SduaxpPsl4qUNefF","type":"function","function":{"name":"add","arguments":"{\"a\":
-      1, \"b\": 2}"}}]},{"role":"tool","tool_call_id":"call_rPuDEhw3SduaxpPsl4qUNefF","content":[{"type":"text","text":"3"}],"name":"add"},{"role":"assistant","content":[{"type":"text","text":"The
-      sum of 1 and 2 is 3."}]},{"role":"user","content":[{"type":"text","text":"List
-      files and then get file1"}]}],"model":"gpt-4o","tools":[{"type":"function","function":{"name":"add","description":"Add
-      two numbers","parameters":{"properties":{"a":{"title":"A","type":"integer"},"b":{"title":"B","type":"integer"}},"required":["a","b"],"title":"addArguments","type":"object"}}},{"type":"function","function":{"name":"files__","description":"uri:files://","parameters":{"properties":{},"required":[],"type":"object"}}},{"type":"function","function":{"name":"files__file_name","description":"uri:files://{file_name}\nGet
-      a file","parameters":{"properties":{"file_name":{"title":"file_name","type":"string"}},"required":["file_name"],"type":"object"}}}]}'
+    body: '{"messages":[{"role":"user","content":[{"type":"text","text":"Use calculator to add 1 and 2"}]},{"role":"assistant","content":null,"tool_calls":[{"id":"call_rPuDEhw3SduaxpPsl4qUNefF","type":"function","function":{"name":"add","arguments":"{\"a\": 1, \"b\": 2}"}}]},{"role":"tool","tool_call_id":"call_rPuDEhw3SduaxpPsl4qUNefF","content":[{"type":"text","text":"3"}],"name":"add"},{"role":"assistant","content":[{"type":"text","text":"The sum of 1 and 2 is 3."}]},{"role":"user","content":[{"type":"text","text":"List files and then get file1"}]}],"model":"gpt-4o","tools":[{"type":"function","function":{"name":"add","description":"Add two numbers","parameters":{"properties":{"a":{"title":"A","type":"integer"},"b":{"title":"B","type":"integer"}},"required":["a","b"],"title":"addArguments","type":"object"}}},{"type":"function","function":{"name":"files__","description":"uri:files://","parameters":{"properties":{},"required":[],"type":"object"}}},{"type":"function","function":{"name":"files__file_name","description":"uri:files://{file_name}\nGet a file","parameters":{"properties":{"file_name":{"title":"file_name","type":"string"}},"required":["file_name"],"type":"object"}}}]}'
     headers:
       content-type:
       - application/json
@@ -117,24 +80,7 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: "{\n  \"id\": \"chatcmpl-BMUlOvu08jVz9CS2DSU1auTeQmdIw\",\n  \"object\":
-        \"chat.completion\",\n  \"created\": 1744701170,\n  \"model\": \"gpt-4o-2024-08-06\",\n
-        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
-        \"assistant\",\n        \"content\": null,\n        \"tool_calls\": [\n          {\n
-        \           \"id\": \"call_UTo8fLOZlIkOd2xlxtwMShYR\",\n            \"type\":
-        \"function\",\n            \"function\": {\n              \"name\": \"files__\",\n
-        \             \"arguments\": \"{}\"\n            }\n          },\n          {\n
-        \           \"id\": \"call_VRXsMgq5xKBdyN2CYfhbjQla\",\n            \"type\":
-        \"function\",\n            \"function\": {\n              \"name\": \"files__file_name\",\n
-        \             \"arguments\": \"{\\\"file_name\\\": \\\"file1\\\"}\"\n            }\n
-        \         }\n        ],\n        \"refusal\": null,\n        \"annotations\":
-        []\n      },\n      \"logprobs\": null,\n      \"finish_reason\": \"tool_calls\"\n
-        \   }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 160,\n    \"completion_tokens\":
-        46,\n    \"total_tokens\": 206,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\":
-        0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
-        {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\":
-        0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\":
-        \"default\",\n  \"system_fingerprint\": \"fp_a6dfaf2bcf\"\n}\n"
+      string: "{\n  \"id\": \"chatcmpl-BMUlOvu08jVz9CS2DSU1auTeQmdIw\",\n  \"object\": \"chat.completion\",\n  \"created\": 1744701170,\n  \"model\": \"gpt-4o-2024-08-06\",\n  \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\": \"assistant\",\n        \"content\": null,\n        \"tool_calls\": [\n          {\n            \"id\": \"call_UTo8fLOZlIkOd2xlxtwMShYR\",\n            \"type\": \"function\",\n            \"function\": {\n              \"name\": \"files__\",\n              \"arguments\": \"{}\"\n            }\n          },\n          {\n            \"id\": \"call_VRXsMgq5xKBdyN2CYfhbjQla\",\n            \"type\": \"function\",\n            \"function\": {\n              \"name\": \"files__file_name\",\n              \"arguments\": \"{\\\"file_name\\\": \\\"file1\\\"}\"\n            }\n          }\n        ],\n        \"refusal\": null,\n        \"annotations\": []\n      },\n      \"logprobs\": null,\n      \"finish_reason\": \"tool_calls\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 160,\n    \"completion_tokens\": 46,\n    \"total_tokens\": 206,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\": 0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\": {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\": 0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\": \"default\",\n  \"system_fingerprint\": \"fp_a6dfaf2bcf\"\n}\n"
     headers:
       Connection:
       - keep-alive
@@ -156,13 +102,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"messages":[{"role":"user","content":[{"type":"text","text":"Use calculator
-      to add 1 and 2"}]},{"role":"assistant","content":null,"tool_calls":[{"id":"call_rPuDEhw3SduaxpPsl4qUNefF","type":"function","function":{"name":"add","arguments":"{\"a\":
-      1, \"b\": 2}"}}]},{"role":"tool","tool_call_id":"call_rPuDEhw3SduaxpPsl4qUNefF","content":[{"type":"text","text":"3"}],"name":"add"},{"role":"assistant","content":[{"type":"text","text":"The
-      sum of 1 and 2 is 3."}]},{"role":"user","content":[{"type":"text","text":"List
-      files and then get file1"}]},{"role":"assistant","content":null,"tool_calls":[{"id":"call_UTo8fLOZlIkOd2xlxtwMShYR","type":"function","function":{"name":"files__","arguments":"{}"}}]},{"role":"tool","tool_call_id":"call_UTo8fLOZlIkOd2xlxtwMShYR","content":[{"type":"text","text":"file1\nfile2"}],"name":"files__"}],"model":"gpt-4o","tools":[{"type":"function","function":{"name":"add","description":"Add
-      two numbers","parameters":{"properties":{"a":{"title":"A","type":"integer"},"b":{"title":"B","type":"integer"}},"required":["a","b"],"title":"addArguments","type":"object"}}},{"type":"function","function":{"name":"files__","description":"uri:files://","parameters":{"properties":{},"required":[],"type":"object"}}},{"type":"function","function":{"name":"files__file_name","description":"uri:files://{file_name}\nGet
-      a file","parameters":{"properties":{"file_name":{"title":"file_name","type":"string"}},"required":["file_name"],"type":"object"}}}]}'
+    body: '{"messages": [{"role": "user", "content": [{"type": "text", "text": "Use calculator to add 1 and 2"}]}, {"role": "assistant", "content": null, "tool_calls": [{"id": "call_rPuDEhw3SduaxpPsl4qUNefF", "type": "function", "function": {"name": "add", "arguments": "{\"a\": 1, \"b\": 2}"}}]}, {"role": "tool", "tool_call_id": "call_rPuDEhw3SduaxpPsl4qUNefF", "content": [{"type": "text", "text": "3"}], "name": "add"}, {"role": "assistant", "content": [{"type": "text", "text": "The sum of 1 and 2 is 3."}]}, {"role": "user", "content": [{"type": "text", "text": "List files and then get file1"}]}, {"role": "assistant", "content": null, "tool_calls": [{"id": "call_UTo8fLOZlIkOd2xlxtwMShYR", "type": "function", "function": {"name": "files__", "arguments": "{}"}}, {"id": "call_VRXsMgq5xKBdyN2CYfhbjQla", "type": "function", "function": {"name": "files__file_name", "arguments": "{\"file_name\": \"file1\"}"}}]}, {"role": "tool", "tool_call_id": "call_UTo8fLOZlIkOd2xlxtwMShYR", "content": [{"type": "text", "text": "file1\nfile2"}]}, {"role": "tool", "tool_call_id": "call_VRXsMgq5xKBdyN2CYfhbjQla", "content": [{"type": "text", "text": "Hello world"}]}], "model": "gpt-4o", "tools": [{"type": "function", "function": {"name": "add", "description": "Add two numbers", "parameters": {"properties": {"a": {"title": "A", "type": "integer"}, "b": {"title": "B", "type": "integer"}}, "required": ["a", "b"], "title": "addArguments", "type": "object"}}}, {"type": "function", "function": {"name": "files__", "description": "uri:files://", "parameters": {"properties": {}, "required": [], "type": "object"}}}, {"type": "function", "function": {"name": "files__file_name", "description": "uri:files://{file_name}\nGet a file", "parameters": {"properties": {"file_name": {"title": "file_name", "type": "string"}}, "required": ["file_name"], "type": "object"}}}]}'
     headers:
       content-type:
       - application/json
@@ -174,74 +114,7 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: "{\n  \"id\": \"chatcmpl-BMUlParr5dwQJI1rEiRSNimDIIQmW\",\n  \"object\":
-        \"chat.completion\",\n  \"created\": 1744701171,\n  \"model\": \"gpt-4o-2024-08-06\",\n
-        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
-        \"assistant\",\n        \"content\": null,\n        \"tool_calls\": [\n          {\n
-        \           \"id\": \"call_g33ZjcvPc66V00Aaw3kXUguc\",\n            \"type\":
-        \"function\",\n            \"function\": {\n              \"name\": \"files__file_name\",\n
-        \             \"arguments\": \"{\\\"file_name\\\":\\\"file1\\\"}\"\n            }\n
-        \         }\n        ],\n        \"refusal\": null,\n        \"annotations\":
-        []\n      },\n      \"logprobs\": null,\n      \"finish_reason\": \"tool_calls\"\n
-        \   }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 183,\n    \"completion_tokens\":
-        19,\n    \"total_tokens\": 202,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\":
-        0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
-        {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\":
-        0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\":
-        \"default\",\n  \"system_fingerprint\": \"fp_a6dfaf2bcf\"\n}\n"
-    headers:
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - ''
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      access-control-expose-headers:
-      - X-Request-ID
-      alt-svc:
-      - h3=":443"; ma=86400
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains; preload
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"messages":[{"role":"user","content":[{"type":"text","text":"Use calculator
-      to add 1 and 2"}]},{"role":"assistant","content":null,"tool_calls":[{"id":"call_rPuDEhw3SduaxpPsl4qUNefF","type":"function","function":{"name":"add","arguments":"{\"a\":
-      1, \"b\": 2}"}}]},{"role":"tool","tool_call_id":"call_rPuDEhw3SduaxpPsl4qUNefF","content":[{"type":"text","text":"3"}],"name":"add"},{"role":"assistant","content":[{"type":"text","text":"The
-      sum of 1 and 2 is 3."}]},{"role":"user","content":[{"type":"text","text":"List
-      files and then get file1"}]},{"role":"assistant","content":null,"tool_calls":[{"id":"call_UTo8fLOZlIkOd2xlxtwMShYR","type":"function","function":{"name":"files__","arguments":"{}"}}]},{"role":"tool","tool_call_id":"call_UTo8fLOZlIkOd2xlxtwMShYR","content":[{"type":"text","text":"file1\nfile2"}],"name":"files__"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_g33ZjcvPc66V00Aaw3kXUguc","type":"function","function":{"name":"files__file_name","arguments":"{\"file_name\":
-      \"file1\"}"}}]},{"role":"tool","tool_call_id":"call_g33ZjcvPc66V00Aaw3kXUguc","content":[{"type":"text","text":"Hello
-      world"}],"name":"files__file_name"}],"model":"gpt-4o","tools":[{"type":"function","function":{"name":"add","description":"Add
-      two numbers","parameters":{"properties":{"a":{"title":"A","type":"integer"},"b":{"title":"B","type":"integer"}},"required":["a","b"],"title":"addArguments","type":"object"}}},{"type":"function","function":{"name":"files__","description":"uri:files://","parameters":{"properties":{},"required":[],"type":"object"}}},{"type":"function","function":{"name":"files__file_name","description":"uri:files://{file_name}\nGet
-      a file","parameters":{"properties":{"file_name":{"title":"file_name","type":"string"}},"required":["file_name"],"type":"object"}}}]}'
-    headers:
-      content-type:
-      - application/json
-      host:
-      - api.openai.com
-      x-stainless-read-timeout:
-      - '600'
-    method: POST
-    uri: https://api.openai.com/v1/chat/completions
-  response:
-    body:
-      string: "{\n  \"id\": \"chatcmpl-BMUlQKhSCXSqLpIBM0RBxDBAojEQb\",\n  \"object\":
-        \"chat.completion\",\n  \"created\": 1744701172,\n  \"model\": \"gpt-4o-2024-08-06\",\n
-        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
-        \"assistant\",\n        \"content\": \"The content of \\\"file1\\\" is \\\"Hello
-        world\\\".\",\n        \"refusal\": null,\n        \"annotations\": []\n      },\n
-        \     \"logprobs\": null,\n      \"finish_reason\": \"stop\"\n    }\n  ],\n
-        \ \"usage\": {\n    \"prompt_tokens\": 213,\n    \"completion_tokens\": 14,\n
-        \   \"total_tokens\": 227,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\":
-        0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
-        {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\":
-        0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\":
-        \"default\",\n  \"system_fingerprint\": \"fp_a6dfaf2bcf\"\n}\n"
+      string: "{\n  \"id\": \"chatcmpl-BMUlQKhSCXSqLpIBM0RBxDBAojEQb\",\n  \"object\": \"chat.completion\",\n  \"created\": 1744701172,\n  \"model\": \"gpt-4o-2024-08-06\",\n  \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\": \"assistant\",\n        \"content\": \"The content of \\\"file1\\\" is \\\"Hello world\\\".\",\n        \"refusal\": null,\n        \"annotations\": []\n      },\n      \"logprobs\": null,\n      \"finish_reason\": \"stop\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 213,\n    \"completion_tokens\": 14,\n    \"total_tokens\": 227,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\": 0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\": {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\": 0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\": \"default\",\n  \"system_fingerprint\": \"fp_a6dfaf2bcf\"\n}\n"
     headers:
       Connection:
       - keep-alive

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -356,3 +356,143 @@ async def test_run_conversation_stream_async_end_to_end():
     assert assistant_messages[-1].content == "It is sunny!"
     # The tool result was sent back as its own tool message on round 2
     assert call_count["n"] == 2
+
+
+class TestCompleteAndCompaction:
+    """complete() and compaction against OpenAI-compatible providers."""
+
+    def _agent_with_mocked_completion(self, text):
+        from unittest.mock import AsyncMock
+
+        agent = Agentlys(
+            provider="openai",
+            model="llama3.1",
+            base_url="http://localhost:11434/v1",
+            instruction="You are a helpful assistant",
+        )
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=text))]
+        )
+        mock_create = AsyncMock(return_value=response)
+        agent.provider.client = SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=mock_create))
+        )
+        return agent, mock_create
+
+    @pytest.mark.asyncio
+    async def test_complete_prepends_system_and_defaults_model(self):
+        agent, mock_create = self._agent_with_mocked_completion("a summary")
+
+        result = await agent.provider.complete(
+            messages=[{"role": "user", "content": "Summarize this"}],
+            system="You summarize conversations",
+        )
+
+        assert result == "a summary"
+        kwargs = mock_create.call_args.kwargs
+        assert kwargs["model"] == "llama3.1"  # falls back to the provider model
+        assert kwargs["messages"][0] == {
+            "role": "system",
+            "content": "You summarize conversations",
+        }
+
+    @pytest.mark.asyncio
+    async def test_compaction_works_with_openai_provider(self):
+        from agentlys.compaction import TokenThresholdCompaction
+
+        agent, mock_create = self._agent_with_mocked_completion(
+            "<summary>Talked about the weather</summary>"
+        )
+        agent.messages = [
+            Message(role="user", content="First message"),
+            Message(role="assistant", content="First response"),
+            Message(role="user", content="Second message"),
+            Message(role="assistant", content="Second response"),
+        ]
+
+        compaction = TokenThresholdCompaction(token_threshold=100)
+        await compaction.compact(agent)
+
+        assert len(agent.messages) == 1
+        assert agent.messages[0].has_compaction
+        assert agent.messages[0].parts[0].content == "Talked about the weather"
+        # The agent instruction rides along as the system message
+        kwargs = mock_create.call_args.kwargs
+        assert kwargs["messages"][0]["role"] == "system"
+        assert kwargs["max_tokens"] == 4096
+
+    @pytest.mark.asyncio
+    async def test_complete_not_implemented_on_bare_provider(self):
+        from agentlys.providers.base_provider import BaseProvider
+
+        class Bare(BaseProvider):
+            def __init__(self, chat, model):
+                self.chat = chat
+                self.model = model
+
+            async def fetch_async(self, **kwargs):
+                return Message(role="assistant", content="hi")
+
+        agent = Agentlys(provider=Bare, model="m")
+        with pytest.raises(NotImplementedError):
+            await agent.provider.complete(messages=[{"role": "user", "content": "x"}])
+
+
+class TestDefaultProviderTransform:
+    """DefaultProvider must apply its string-only wire format."""
+
+    def _agent(self):
+        return Agentlys(
+            provider="default",
+            model="m",
+            base_url="http://localhost:1234/v1",
+            instruction="Be brief",
+        )
+
+    def test_system_messages_are_strings(self):
+        agent = self._agent()
+        agent.messages = [Message(role="user", content="Hello")]
+        messages, _, _ = agent.provider._prepare_request_params()
+        assert messages[0] == {"role": "system", "content": "Be brief"}
+
+    def test_tool_results_are_strings(self):
+        agent = self._agent()
+        agent.messages = [
+            Message(role="user", content="Weather?"),
+            Message(
+                role="assistant",
+                parts=[
+                    MessagePart(
+                        type="function_call",
+                        function_call={"name": "get_weather", "arguments": {}},
+                        function_call_id="call_1",
+                    )
+                ],
+            ),
+            Message(
+                role="function",
+                name="get_weather",
+                parts=[
+                    MessagePart(
+                        type="function_result",
+                        content="sunny",
+                        function_call_id="call_1",
+                    )
+                ],
+            ),
+        ]
+        messages, _, _ = agent.provider._prepare_request_params()
+        tool_message = next(m for m in messages if m["role"] == "tool")
+        assert tool_message["content"] == "sunny"
+        assert tool_message["tool_call_id"] == "call_1"
+
+
+def test_compaction_part_serializes_as_text():
+    """Post-compaction history must serialize on the OpenAI wire format."""
+    from agentlys.providers.openai import parts_to_openai_dict
+
+    part = MessagePart(type="compaction", content="Talked about the weather")
+    result = parts_to_openai_dict(part)
+    assert result["type"] == "text"
+    assert "[Previous conversation summary]" in result["text"]
+    assert "Talked about the weather" in result["text"]

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -1,0 +1,358 @@
+"""Tests for using any OpenAI-compatible API (Ollama, vLLM, LiteLLM, ...).
+
+These tests never hit the network: they only check client configuration
+and the parsing/serialization of OpenAI-style payloads.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from agentlys import Agentlys
+from agentlys.model import Message, MessagePart
+from agentlys.providers.openai import (
+    from_openai_object,
+    message_to_openai_dict,
+    split_function_results,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for var in ("AGENTLYS_HOST", "AGENTLYS_API_KEY", "AGENTLYS_PROVIDER"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+
+
+class TestClientConfiguration:
+    def test_default_base_url(self):
+        agent = Agentlys(provider="openai", model="gpt-4o")
+        assert str(agent.provider.client.base_url) == "https://api.openai.com/v1/"
+        assert agent.provider.client.api_key == "sk-from-env"
+
+    def test_explicit_base_url_and_api_key(self):
+        agent = Agentlys(
+            provider="openai",
+            model="llama3.1",
+            base_url="http://localhost:11434/v1",
+            api_key="ollama",
+        )
+        assert str(agent.provider.client.base_url) == "http://localhost:11434/v1/"
+        assert agent.provider.client.api_key == "ollama"
+
+    def test_env_base_url_and_api_key(self, monkeypatch):
+        monkeypatch.setenv("AGENTLYS_HOST", "https://openrouter.ai/api/v1")
+        monkeypatch.setenv("AGENTLYS_API_KEY", "sk-or-123")
+        agent = Agentlys(provider="openai", model="some-model")
+        assert str(agent.provider.client.base_url) == "https://openrouter.ai/api/v1/"
+        assert agent.provider.client.api_key == "sk-or-123"
+
+    def test_explicit_arguments_beat_env(self, monkeypatch):
+        monkeypatch.setenv("AGENTLYS_HOST", "https://env-host.example/v1")
+        monkeypatch.setenv("AGENTLYS_API_KEY", "env-key")
+        agent = Agentlys(
+            provider="openai",
+            model="m",
+            base_url="http://localhost:8000/v1",
+            api_key="arg-key",
+        )
+        assert str(agent.provider.client.base_url) == "http://localhost:8000/v1/"
+        assert agent.provider.client.api_key == "arg-key"
+
+    def test_keyless_custom_endpoint_gets_placeholder_key(self, monkeypatch):
+        # Key-less local servers (Ollama, vLLM, ...) must work without any
+        # API key configured — the SDK refuses to build a client without one.
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        agent = Agentlys(
+            provider="openai", model="llama3.1", base_url="http://localhost:11434/v1"
+        )
+        assert agent.provider.client.api_key == "not-needed"
+
+    def test_provider_from_env(self, monkeypatch):
+        monkeypatch.setenv("AGENTLYS_PROVIDER", "openai")
+        monkeypatch.setenv("AGENTLYS_HOST", "http://localhost:4000")
+        agent = Agentlys(model="my-model")
+        assert agent.provider.__class__.__name__ == "OpenAIProvider"
+        assert (
+            str(agent.provider.client.base_url).rstrip("/") == "http://localhost:4000"
+        )
+
+    def test_default_provider_honors_base_url(self):
+        agent = Agentlys(
+            provider="default",
+            model="m",
+            base_url="http://localhost:1234/v1",
+            api_key="k",
+        )
+        assert str(agent.provider.client.base_url) == "http://localhost:1234/v1/"
+        assert agent.provider.client.api_key == "k"
+
+
+def _tool_call(id, name, arguments):
+    return SimpleNamespace(
+        id=id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+class TestParallelToolCalls:
+    def test_from_openai_object_keeps_all_tool_calls(self):
+        message = from_openai_object(
+            role="assistant",
+            content=None,
+            tool_calls=[
+                _tool_call("call_1", "get_weather", '{"city": "Paris"}'),
+                _tool_call("call_2", "get_time", '{"tz": "CET"}'),
+            ],
+            id="resp_1",
+        )
+        assert len(message.function_call_parts) == 2
+        assert message.function_call_parts[0].function_call["name"] == "get_weather"
+        assert message.function_call_parts[1].function_call_id == "call_2"
+
+    def test_message_to_openai_dict_serializes_all_tool_calls(self):
+        message = Message(
+            role="assistant",
+            parts=[
+                MessagePart(
+                    type="function_call",
+                    function_call={"name": "f1", "arguments": {"a": 1}},
+                    function_call_id="call_1",
+                ),
+                MessagePart(
+                    type="function_call",
+                    function_call={"name": "f2", "arguments": {"b": 2}},
+                    function_call_id="call_2",
+                ),
+            ],
+        )
+        res = message_to_openai_dict(message)
+        assert [t["id"] for t in res["tool_calls"]] == ["call_1", "call_2"]
+
+    def test_split_function_results_one_tool_message_per_call(self):
+        combined = Message(
+            role="function",
+            parts=[
+                MessagePart(
+                    type="function_result", content="r1", function_call_id="call_1"
+                ),
+                MessagePart(
+                    type="function_result", content="r2", function_call_id="call_2"
+                ),
+            ],
+        )
+        split = split_function_results([combined])
+        assert len(split) == 2
+        dicts = [message_to_openai_dict(m) for m in split]
+        assert dicts[0]["tool_call_id"] == "call_1"
+        assert dicts[1]["tool_call_id"] == "call_2"
+
+    def test_split_function_results_keeps_single_result_untouched(self):
+        single = Message(
+            role="function",
+            name="f1",
+            parts=[
+                MessagePart(
+                    type="function_result", content="r1", function_call_id="call_1"
+                )
+            ],
+        )
+        assert split_function_results([single]) == [single]
+
+
+def _stream_chunk(id="resp_1", delta=None, usage=None):
+    choices = []
+    if delta is not None:
+        choices = [SimpleNamespace(delta=delta)]
+    return SimpleNamespace(id=id, choices=choices, usage=usage)
+
+
+def _delta(content=None, role=None, tool_calls=None):
+    return SimpleNamespace(content=content, role=role, tool_calls=tool_calls)
+
+
+def _delta_tool_call(index, id=None, name=None, arguments=None):
+    return SimpleNamespace(
+        index=index,
+        id=id,
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+class _FakeStreamClient:
+    """Minimal stand-in for AsyncOpenAI limited to streaming completions."""
+
+    def __init__(self, chunks):
+        self._chunks = chunks
+        self.kwargs = None
+
+        async def create(**kwargs):
+            self.kwargs = kwargs
+
+            async def iterator():
+                for chunk in chunks:
+                    yield chunk
+
+            return iterator()
+
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=create))
+
+
+@pytest.mark.asyncio
+async def test_fetch_stream_async_text():
+    agent = Agentlys(provider="openai", model="gpt-4o")
+    agent.messages.append(Message(role="user", content="Hello"))
+    client = _FakeStreamClient(
+        [
+            _stream_chunk(delta=_delta(role="assistant", content="Hel")),
+            _stream_chunk(delta=_delta(content="lo!")),
+            _stream_chunk(
+                delta=None,
+                usage=SimpleNamespace(prompt_tokens=5, completion_tokens=2),
+            ),
+        ]
+    )
+    agent.provider.client = client
+
+    events = [event async for event in agent.provider.fetch_stream_async()]
+
+    assert client.kwargs["stream"] is True
+    text_events = [e for e in events if e["type"] == "text"]
+    assert [e["content"] for e in text_events] == ["Hel", "lo!"]
+    final = events[-1]
+    assert final["type"] == "message"
+    assert final["message"].content == "Hello!"
+    assert final["message"].usage == {"input_tokens": 5, "output_tokens": 2}
+
+
+@pytest.mark.asyncio
+async def test_fetch_stream_async_accumulates_tool_calls():
+    agent = Agentlys(provider="openai", model="gpt-4o")
+    agent.messages.append(Message(role="user", content="Weather in Paris and Lyon?"))
+    client = _FakeStreamClient(
+        [
+            _stream_chunk(
+                delta=_delta(
+                    role="assistant",
+                    tool_calls=[
+                        _delta_tool_call(0, id="call_1", name="get_weather"),
+                    ],
+                )
+            ),
+            _stream_chunk(
+                delta=_delta(
+                    tool_calls=[
+                        _delta_tool_call(0, arguments='{"city": '),
+                        _delta_tool_call(0, arguments='"Paris"}'),
+                        _delta_tool_call(
+                            1,
+                            id="call_2",
+                            name="get_weather",
+                            arguments='{"city": "Lyon"}',
+                        ),
+                    ]
+                )
+            ),
+        ]
+    )
+    agent.provider.client = client
+
+    events = [event async for event in agent.provider.fetch_stream_async()]
+
+    final_message = events[-1]["message"]
+    parts = final_message.function_call_parts
+    assert len(parts) == 2
+    assert parts[0].function_call == {
+        "name": "get_weather",
+        "arguments": {"city": "Paris"},
+    }
+    assert parts[0].function_call_id == "call_1"
+    assert parts[1].function_call["arguments"] == {"city": "Lyon"}
+
+
+@pytest.mark.asyncio
+async def test_fetch_stream_async_sends_tools():
+    agent = Agentlys(provider="openai", model="gpt-4o")
+
+    def get_weather(city: str) -> str:
+        """Get the weather for a city"""
+        return "sunny"
+
+    agent.add_function(get_weather)
+    agent.messages.append(Message(role="user", content="Weather in Paris?"))
+    client = _FakeStreamClient(
+        [_stream_chunk(delta=_delta(role="assistant", content="Sunny"))]
+    )
+    agent.provider.client = client
+
+    async for _ in agent.provider.fetch_stream_async():
+        pass
+
+    tool_names = [t["function"]["name"] for t in client.kwargs["tools"]]
+    assert tool_names == ["get_weather"]
+
+
+@pytest.mark.asyncio
+async def test_run_conversation_stream_async_end_to_end():
+    """The full streaming tool loop works against an OpenAI-compatible client."""
+    agent = Agentlys(
+        provider="openai",
+        model="llama3.1",
+        base_url="http://localhost:11434/v1",
+        instruction="You are a helpful assistant",
+    )
+
+    def get_weather(city: str) -> str:
+        """Get the weather for a city"""
+        return "sunny"
+
+    agent.add_function(get_weather)
+
+    call_count = {"n": 0}
+
+    async def create(**kwargs):
+        call_count["n"] += 1
+
+        if call_count["n"] == 1:
+            chunks = [
+                _stream_chunk(
+                    delta=_delta(
+                        role="assistant",
+                        tool_calls=[
+                            _delta_tool_call(
+                                0,
+                                id="call_1",
+                                name="get_weather",
+                                arguments=json.dumps({"city": "Paris"}),
+                            )
+                        ],
+                    )
+                )
+            ]
+        else:
+            chunks = [
+                _stream_chunk(delta=_delta(role="assistant", content="It is sunny!"))
+            ]
+
+        async def iterator():
+            for chunk in chunks:
+                yield chunk
+
+        return iterator()
+
+    agent.provider.client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create))
+    )
+
+    events = [
+        event
+        async for event in agent.run_conversation_stream_async("Weather in Paris?")
+    ]
+
+    types = [e["type"] for e in events]
+    assert "tool_result" in types
+    assistant_messages = [e["message"] for e in events if e["type"] == "assistant"]
+    assert assistant_messages[-1].content == "It is sunny!"
+    # The tool result was sent back as its own tool message on round 2
+    assert call_count["n"] == 2

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -16,7 +16,18 @@ async def async_calculator(**kwargs):
 @pytest.mark.asyncio
 async def test_fetch_stream_async_not_implemented_raises_error():
     """Test that providers without streaming support raise NotImplementedError."""
-    chat = Agentlys(provider=APIProvider.OPENAI)
+    from agentlys.base import AgentlysBase
+    from agentlys.providers.base_provider import BaseProvider
+
+    class NoStreamProvider(BaseProvider):
+        def __init__(self, chat: AgentlysBase, model: str):
+            self.chat = chat
+            self.model = model
+
+        async def fetch_async(self, **kwargs) -> Message:
+            return Message(role="assistant", content="Hello")
+
+    chat = Agentlys(provider=NoStreamProvider, model="test-model")
     chat.messages.append(Message(role="user", content="Hello"))
 
     with pytest.raises(NotImplementedError) as exc_info:
@@ -24,7 +35,7 @@ async def test_fetch_stream_async_not_implemented_raises_error():
             pass
 
     assert "does not support streaming" in str(exc_info.value)
-    assert "OpenAIProvider" in str(exc_info.value)
+    assert "NoStreamProvider" in str(exc_info.value)
 
 
 async def mock_stream_chunks():

--- a/tests/test_tool_state.py
+++ b/tests/test_tool_state.py
@@ -48,8 +48,8 @@ class TestToolState(unittest.TestCase):
         class_name = mock_tool.__class__.__name__
         tool_id = agent.add_tool(mock_tool)
 
-        # Mock the client.messages.create method
-        def mock_create(*args, **kwargs):
+        # Mock the client.chat.completions.create method
+        async def mock_create(*args, **kwargs):
             # Check if the tool representation is in the system message
             messages = kwargs.get("messages", [])
             system_messages = [msg for msg in messages if msg.get("role") == "system"]
@@ -81,6 +81,7 @@ class TestToolState(unittest.TestCase):
             class MockResponse:
                 id = None
                 choices = [MockResponseChoice]
+                usage = None
 
             return MockResponse()
 


### PR DESCRIPTION
## Summary

The `openai` provider now works with any API speaking the OpenAI chat completions protocol (Ollama, vLLM, LiteLLM, OpenRouter, Together, Groq, self-hosted models, ...), and compaction works with every provider.

```python
# Ollama running locally (no API key needed)
agent = Agentlys(provider="openai", model="llama3.1", base_url="http://localhost:11434/v1")
```

Or via env: `AGENTLYS_PROVIDER=openai`, `AGENTLYS_HOST=...`, `AGENTLYS_API_KEY=...`, `AGENTLYS_MODEL=...`.

## Changes

### Configuration
- Thread `base_url` / `api_key` through `Agentlys()` → `get_provider_and_model` → all providers. The `base_url` parameter on the OpenAI providers existed but was **silently ignored**.
- New `AGENTLYS_API_KEY` env var; `AGENTLYS_HOST` is now read at provider init instead of import time. Resolution order: explicit args > `AGENTLYS_*` env > provider defaults.
- Key-less endpoints (Ollama, vLLM, ...) get a placeholder API key so the SDK accepts them.
- Fix provider selection env var: `get_provider_and_model` read `AGENTLYS_HOST` where it meant `AGENTLYS_PROVIDER`, so env-based provider selection never worked. `Agentlys()` now defaults to `AGENTLYS_PROVIDER`, then `"openai"`.

### Streaming
- Switch the OpenAI provider family to `AsyncOpenAI` (the sync client was blocking the event loop inside `fetch_async`) and implement `fetch_stream_async`, so `run_conversation_stream_async` works with OpenAI-compatible APIs — previously Anthropic-only.

### Parallel tool calls (OpenAI path)
- Keep **all** `tool_calls` from responses — previously only the first was kept, orphaning the rest and causing a 400 on the next request with models that emit parallel calls.
- Serialize multiple `tool_calls` per assistant message (was overwriting), and split combined tool results into one `role:"tool"` message per `tool_call_id` as the protocol requires.
- Normalize `usage` to `input_tokens`/`output_tokens` on returned Messages (feeds `TokenThresholdCompaction.should_compact`).

### Compaction works with any provider
- New `BaseProvider.complete()` one-shot completion hook, implemented by `AnthropicProvider` (keeps the proxy `_get_auth_headers` injection, so Myriade's `ProxyProvider` inherits it unchanged) and `OpenAIProvider` (inherited by default/shim/legacy). `compact()` delegates to it instead of assuming an Anthropic-shaped `provider.client`.
- `TokenThresholdCompaction.summary_model` now defaults to the provider's current model instead of a hardcoded Claude model (which guaranteed an error on non-Anthropic providers). Pass a cheap model explicitly to keep summaries inexpensive — Myriade already does.
- Fix a latent crash: the first request **after** a compaction failed with `Unknown part type: compaction` on the OpenAI path — the `compaction` part type is now serialized as text (main + legacy serializers), matching Anthropic.

### Dead code cleanup
- `DefaultProvider.message_to_openai_dict` was never used (the inherited `fetch_async` always used the base serializer). Added an overridable `OpenAIProvider.message_transform` hook and registered it, so the documented string-only system/tool content behavior is real again — useful for strict compat servers that reject list-of-parts content.
- Removed `Agentlys.client` (always `None`), the unused `AGENTLYS_HOST` constant in `chat.py`, and the no-op `OpenAIProviderFunctionShim.__init__`.
- Fixed `FunctionCallParsingError.__str__` referencing a nonexistent attribute, and the `(None,)` tuple typo on `AgentlysBase.instruction`.

## Notes for reviewers

- **Behavior changes**: `provider.client` on the OpenAI family is now `AsyncOpenAI` (was sync `OpenAI`); `DefaultProvider` now sends string system/tool content as documented; custom providers extending `BaseProvider` directly must implement `complete()` to use compaction.
- The multi-turn OpenAI cassette was rewritten: it had recorded the model emitting two parallel tool calls that the old code silently dropped (forcing an extra round-trip); the new flow answers in 2 interactions instead of 3.
- `tests/test_parse_template.py::test_full_payload_instruction_in_system` is flaky when run in the full suite — it also fails on unmodified `master` (test-ordering issue with `asyncio.get_event_loop()`), unrelated to this PR.

## Tests

- 22 new tests in `tests/test_openai_compat.py` (client configuration, env resolution, parallel tool calls, streaming accumulation, provider-agnostic `complete()`, compaction with the OpenAI provider, `DefaultProvider` wire format) — all network-free.
- Verified end-to-end against a local HTTP server implementing the OpenAI protocol (SSE streaming + parallel tool calls, no auth): full tool loops (stream and non-stream), key-less endpoint, and mid-conversation compaction for both `openai` and `default` providers.
- `uv run pytest`: 227 passed. `ruff check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fTT3WqQnNRdjCUcLVhemB

---
_Generated by [Claude Code](https://claude.ai/code/session_014fTT3WqQnNRdjCUcLVhemB)_