### PR TITLE
fix: tool lifecycle, history mutation and formatting bugs + perf and cleanup

### DIFF
--- a/src/agentlys/chat.py
+++ b/src/agentlys/chat.py
@@ -1,6 +1,4 @@
-"""Agentlys package."""
-
-__version__ = "0.4.1"
+"""Agentlys chat loop: agent state, tool registration and conversation runs."""
 
 import asyncio
 import copy
@@ -13,6 +11,7 @@ import traceback
 import typing
 import uuid
 import warnings
+import weakref
 from typing import TYPE_CHECKING, Type
 
 from PIL import Image as PILImage
@@ -75,6 +74,31 @@ def _resolve_thinking_for_model(
     return thinking
 
 
+_from_response_cache: "weakref.WeakKeyDictionary" = weakref.WeakKeyDictionary()
+
+
+def _accepts_from_response(func) -> bool:
+    """Whether the callable declares a ``from_response`` parameter.
+
+    Cached per underlying function: signature reflection on every tool
+    invocation adds up in long agent loops.
+    """
+    target = getattr(func, "__func__", func)
+    try:
+        return _from_response_cache[target]
+    except KeyError:
+        pass
+    except TypeError:
+        # Not weak-referenceable/hashable — fall back to direct inspection
+        return "from_response" in inspect.signature(func).parameters
+    result = "from_response" in inspect.signature(func).parameters
+    try:
+        _from_response_cache[target] = result
+    except TypeError:
+        pass
+    return result
+
+
 def _truncate_with_warning(text: str, limit: int = OUTPUT_SIZE_LIMIT) -> str:
     """Truncate text to limit and add warning if truncated."""
     if len(text) > limit:
@@ -115,7 +139,7 @@ class Agentlys(AgentlysBase):
         model=AGENTLYS_MODEL,
         provider: typing.Union[str, Type[BaseProvider], None] = None,
         use_tools_only: bool = False,
-        mcp_servers: typing.Union[list[object], None] = [],
+        mcp_servers: typing.Union[list[object], None] = None,
         thinking: typing.Optional[dict] = None,
         compaction: typing.Optional["CompactionHandler"] = None,
         cancel_event: typing.Optional[asyncio.Event] = None,
@@ -180,8 +204,14 @@ class Agentlys(AgentlysBase):
         self.on_sub_agent_event: typing.Optional[typing.Callable] = None
         self._tool_search_config = None
         self._tool_search_function_name: typing.Optional[str] = None
-        for m in mcp_servers:
-            self.add_mcp_server(m)
+        if mcp_servers:
+            # add_mcp_server is async; calling it from __init__ silently
+            # created never-awaited coroutines and registered nothing.
+            raise ValueError(
+                "mcp_servers cannot be registered from the constructor because "
+                "registration is async. Use `await agent.add_mcp_server(server)` "
+                "instead."
+            )
 
     def _check_cancel(self):
         """Raise StopLoopException if the cancel event has been set."""
@@ -218,13 +248,19 @@ class Agentlys(AgentlysBase):
             return False
         return any(part.type == "function_call" for part in (last.parts or []))
 
-    async def _maybe_compact(self, next_message: typing.Optional[Message]) -> bool:
-        """Run compaction if safe. Returns True if compaction executed."""
+    def _compaction_allowed(self, next_message: typing.Optional[Message]) -> bool:
+        """True if compaction is configured and safe to run right now."""
         if not (self.compaction and hasattr(self.compaction, "should_compact")):
             return False
         if self._is_tool_result_message(next_message):
             return False
         if self._has_unanswered_tool_use():
+            return False
+        return True
+
+    async def _maybe_compact(self, next_message: typing.Optional[Message]) -> bool:
+        """Run compaction if safe. Returns True if compaction executed."""
+        if not self._compaction_allowed(next_message):
             return False
         if not await self.compaction.should_compact(self):
             return False
@@ -284,20 +320,22 @@ class Agentlys(AgentlysBase):
         # If there are no tools, return None
         if not self.tools:
             return None
+        # When tool search is enabled, skip __llm__ for tools whose
+        # methods are ALL deferred — they haven't been discovered yet.
+        loaded_tool_names = None
+        if self._tool_search_config:
+            loaded_tool_names = {
+                s["name"].split("__", 1)[0]
+                for s in self.functions_schema
+                if not s.get("defer_loading")
+            }
+
         tool_reprs = []
         for tool_id, tool in self.tools.items():
             tool_name = f"{tool.__class__.__name__}-{tool_id}"
 
-            # When tool search is enabled, skip __llm__ for tools whose
-            # methods are ALL deferred — they haven't been discovered yet.
-            if self._tool_search_config:
-                prefix = f"{tool_name}__"
-                has_loaded_method = any(
-                    s["name"].startswith(prefix) and not s.get("defer_loading")
-                    for s in self.functions_schema
-                )
-                if not has_loaded_method:
-                    continue
+            if loaded_tool_names is not None and tool_name not in loaded_tool_names:
+                continue
 
             if hasattr(tool, "__llm__"):
                 tool_output = tool.__llm__()
@@ -438,12 +476,17 @@ class Agentlys(AgentlysBase):
         return tool_id
 
     def remove_tool(self, tool_id: str):
-        del self.tools[tool_id]
+        tool = self.tools.pop(tool_id)
+        prefix = f"{tool.__class__.__name__}-{tool_id}__"
         self.functions_schema = [
-            schema for schema in self.functions_schema if schema["name"] != tool_id
+            schema
+            for schema in self.functions_schema
+            if not schema["name"].startswith(prefix)
         ]
         self.functions = {
-            name: func for name, func in self.functions.items() if name != tool_id
+            name: func
+            for name, func in self.functions.items()
+            if not name.startswith(prefix)
         }
 
     def add_sub_agent(
@@ -812,13 +855,11 @@ class Agentlys(AgentlysBase):
                 for item in content:
                     if isinstance(item, str):
                         formatted_content.append(item)
-                    elif isinstance(item, object):
-                        tool_id = self.add_tool(item)
-                        formatted_content.append(f"Added tool: {tool_id}")
-                    elif isinstance(item, (int, float, bool)):
+                    elif isinstance(item, (bool, int, float)):
                         formatted_content.append(str(item))
                     else:
-                        raise ValueError(f"Invalid item type: {type(item)}")
+                        tool_id = self.add_tool(item)
+                        formatted_content.append(f"Added tool: {tool_id}")
                 formatted_content = "\n".join(formatted_content)
                 # Limit the size of the content
                 if len(formatted_content) > OUTPUT_SIZE_LIMIT:
@@ -939,7 +980,7 @@ class Agentlys(AgentlysBase):
             with call_scope() as scoped_owner:
                 scoped_func = getattr(scoped_owner, func.__name__)
                 call_kwargs = kwargs
-                if "from_response" in inspect.signature(scoped_func).parameters:
+                if _accepts_from_response(scoped_func):
                     call_kwargs = {**kwargs, "from_response": from_response}
                 return scoped_func(**call_kwargs)
 
@@ -958,8 +999,7 @@ class Agentlys(AgentlysBase):
         )
 
     async def _invoke_func(self, func, from_response, **kwargs):
-        sig = inspect.signature(func)
-        if "from_response" in sig.parameters:
+        if _accepts_from_response(func):
             kwargs = {**kwargs, "from_response": from_response}
 
         # Async tools: await them directly on the event loop.
@@ -980,16 +1020,12 @@ class Agentlys(AgentlysBase):
     async def _resolve_and_call_function(
         self, name: str, args: dict, response: Message
     ) -> typing.Any:
-        """Resolve function/tool by name and call it with args."""
-        if name.startswith("tool-"):
-            tool_id, method_name = name.split("__")
-            tool = self.tools[tool_id]
-            method = getattr(tool, method_name)
-            return await self._call_with_signature(method, response, **args)
-        else:
-            return await self._call_with_signature(
-                self.functions[name], response, **args
-            )
+        """Resolve function/tool by name and call it with args.
+
+        Tool methods are registered in self.functions like any other
+        function (see add_tool), so a single lookup covers both.
+        """
+        return await self._call_with_signature(self.functions[name], response, **args)
 
     def _process_tool_result(self, result: typing.Any) -> tuple[typing.Any, typing.Any]:
         """Process tool result and handle tuple unpacking.
@@ -1007,34 +1043,6 @@ class Agentlys(AgentlysBase):
             content = result
 
         return content, image
-
-    async def _call_function_and_build_message(
-        self, function_name, function_arguments, response
-    ):
-        """
-        Encapsulate the 'call the function' logic & handle exceptions
-        plus building a function or tool response message.
-        """
-        content = None
-        image = None
-
-        try:
-            result = await self._resolve_and_call_function(
-                function_name, function_arguments, response
-            )
-            content, image = self._process_tool_result(result)
-        except StopLoopException:
-            raise
-        except Exception as e:
-            content = self._format_exception(e)
-
-        # Build next message
-        return self._format_callback_message(
-            function_name=function_name,
-            function_call_id=response.function_call_id,
-            content=content,
-            image=image,
-        )
 
     async def _execute_single_tool(
         self,
@@ -1238,12 +1246,8 @@ class Agentlys(AgentlysBase):
         # Run compaction before appending the new message so it is never
         # included in the summary — the LLM must see the exact user request.
         # Skipped mid tool exchange to avoid orphaning tool_use/tool_result.
-        if (
-            self.compaction
-            and hasattr(self.compaction, "should_compact")
-            and not self._is_tool_result_message(message)
-            and not self._has_unanswered_tool_use()
-            and await self.compaction.should_compact(self)
+        if self._compaction_allowed(message) and await self.compaction.should_compact(
+            self
         ):
             yield {"type": "compacting"}
             await self.compaction.compact(self)

--- a/src/agentlys/mcp.py
+++ b/src/agentlys/mcp.py
@@ -15,6 +15,18 @@ _TOOL_NAME_SANITIZE_RE = re.compile(r"[^a-zA-Z0-9_-]")
 ToolFilter = typing.Callable[[typing.Any], bool]
 
 
+def _truncate_result(
+    text: str, max_result_chars: typing.Optional[int], hint: str = ""
+) -> str:
+    """Truncate an MCP result to max_result_chars with an explicit marker."""
+    if max_result_chars is None or len(text) <= max_result_chars:
+        return text
+    return (
+        text[:max_result_chars]
+        + f"\n[... truncated to {max_result_chars} characters.{hint}]"
+    )
+
+
 def sanitize_tool_name(name: str, prefix: str = "") -> str:
     """Make an MCP tool name safe for LLM providers.
 
@@ -56,13 +68,11 @@ def convert_tool_result(result, max_result_chars: typing.Optional[int] = None) -
     if not text:
         text = "(empty result)"
 
-    if max_result_chars is not None and len(text) > max_result_chars:
-        text = (
-            text[:max_result_chars]
-            + f"\n[... truncated to {max_result_chars} characters."
-            + " Refine the call (filters, pagination) to get less data.]"
-        )
-    return text
+    return _truncate_result(
+        text,
+        max_result_chars,
+        hint=" Refine the call (filters, pagination) to get less data.",
+    )
 
 
 async def fetch_mcp_server_tools(
@@ -192,12 +202,7 @@ async def fetch_mcp_server_resources(
                     else:
                         parts.append("[binary content omitted]")
                 text = "\n".join(parts) or "(empty result)"
-                if max_result_chars is not None and len(text) > max_result_chars:
-                    text = (
-                        text[:max_result_chars]
-                        + f"\n[... truncated to {max_result_chars} characters.]"
-                    )
-                return text
+                return _truncate_result(text, max_result_chars)
 
             return read_resource
 

--- a/src/agentlys/model.py
+++ b/src/agentlys/model.py
@@ -15,21 +15,32 @@ class Image:
         if not isinstance(image, PILImage.Image):
             raise TypeError("image must be an instance of PIL.Image.Image")
         self.image = image
+        self._base64_cache: typing.Optional[str] = None
 
     def resize(self, size: tuple[int, int]):
         try:
+            # PIL drops .format on derived images; keep it so later
+            # serialization still knows the encoding.
+            image_format = self.image.format
             self.image = self.image.resize(size)
+            self.image.format = image_format
         except Exception as e:
             raise ValueError(f"Failed to resize image: {e}")
+        self._base64_cache = None
 
     def to_base64(self):
+        # Providers re-serialize the whole history on every request; encoding
+        # is memoized so each image is PNG/base64-encoded only once.
+        if self._base64_cache is not None:
+            return self._base64_cache
         try:
             buffered = BytesIO()
             self.image.save(buffered, format=self.image.format)
             img_str = base64.b64encode(buffered.getvalue()).decode()
-            return img_str
         except Exception as e:
             raise ValueError(f"Failed to convert image to base64: {e}")
+        self._base64_cache = img_str
+        return img_str
 
     @classmethod
     def from_bytes(cls, img_bytes: bytes):
@@ -195,14 +206,15 @@ class Message:
         if self.role == "function":
             raise ValueError("Function messages cannot have content")
         # 1. get all text parts
-        text_parts = [part.content for part in self.parts if part.type == "text"]
+        text_parts = [part for part in self.parts if part.type == "text"]
         # 2. verify that there is only one text part
         if not text_parts:
             raise ValueError("Message has no text part")
         if len(text_parts) > 1:
             raise ValueError("Message has multiple text parts")
-        # 3. set the sugar syntax
-        self.parts[0].content = value
+        # 3. set the sugar syntax on the text part (parts[0] may be
+        # a thinking block or another non-text part)
+        text_parts[0].content = value
 
     @property
     def function_call(self) -> typing.Optional[dict]:

--- a/src/agentlys/providers/anthropic.py
+++ b/src/agentlys/providers/anthropic.py
@@ -184,103 +184,104 @@ class AnthropicProvider(BaseProvider):
                 result.append(msg)
         return result
 
-    def _prepare_request_params(self, **kwargs):
-        """Prepare messages, tools, and kwargs for Anthropic API request."""
-        messages = self.prepare_messages(
-            transform_function=lambda m: message_to_anthropic_dict(m),
-            transform_list_function=add_empty_function_result,
-        )
+    @staticmethod
+    def _merge_same_role_messages(messages: list[dict]) -> list[dict]:
+        """Merge consecutive messages sharing the same role.
 
-        if self.chat.instruction:
-            system = self.chat.instruction
-        else:
-            system = None
+        The Anthropic API rejects two consecutive messages with the same
+        role, e.g. a tool_result message directly followed by a user message.
+        """
+        merged_messages = []
+        for message in messages:
+            if merged_messages and merged_messages[-1]["role"] == message["role"]:
+                # Convert string content to list format for merging
+                if isinstance(merged_messages[-1]["content"], str):
+                    merged_messages[-1]["content"] = [
+                        {
+                            "type": "text",
+                            "text": merged_messages[-1]["content"],
+                        }
+                    ]
 
-        def merge_messages(messages):
-            """
-            When two messages are in the same role, we merge the following message into the previous.
-            {
-                "role": "user",
-                "content": [
-                    {
-                    "type": "tool_result",
-                    "tool_use_id": "example_19",
-                    "content": ""
-                    }
-                ]
-            },
-            {
-                "role": "user",
-                "content": "Plot distribution of stations per city"
-            }
-            """
-            merged_messages = []
-            for message in messages:
-                if merged_messages and merged_messages[-1]["role"] == message["role"]:
-                    # Convert string content to list format for merging
-                    if isinstance(merged_messages[-1]["content"], str):
-                        merged_messages[-1]["content"] = [
-                            {
-                                "type": "text",
-                                "text": merged_messages[-1]["content"],
-                            }
-                        ]
+                if not isinstance(merged_messages[-1]["content"], list):
+                    raise ValueError(
+                        f"Invalid content type: {type(merged_messages[-1]['content'])}"
+                    )
 
-                    if not isinstance(merged_messages[-1]["content"], list):
-                        raise ValueError(
-                            f"Invalid content type: {type(merged_messages[-1]['content'])}"
-                        )
+                # Track existing tool_use_ids to prevent duplicates
+                existing_tool_use_ids = {
+                    c.get("tool_use_id")
+                    for c in merged_messages[-1]["content"]
+                    if isinstance(c, dict) and c.get("type") == "tool_result"
+                }
+                # Only add content blocks that aren't duplicate tool_results
+                for content_block in message["content"]:
+                    if (
+                        isinstance(content_block, dict)
+                        and content_block.get("type") == "tool_result"
+                    ):
+                        tool_use_id = content_block.get("tool_use_id")
+                        if tool_use_id in existing_tool_use_ids:
+                            continue
+                        existing_tool_use_ids.add(tool_use_id)
+                    merged_messages[-1]["content"].append(content_block)
+            else:
+                merged_messages.append(message)
+        return merged_messages
 
-                    # Track existing tool_use_ids to prevent duplicates
-                    existing_tool_use_ids = {
-                        c.get("tool_use_id")
-                        for c in merged_messages[-1]["content"]
-                        if isinstance(c, dict) and c.get("type") == "tool_result"
-                    }
-                    # Only add content blocks that aren't duplicate tool_results
-                    for content_block in message["content"]:
-                        if (
-                            isinstance(content_block, dict)
-                            and content_block.get("type") == "tool_result"
-                        ):
-                            tool_use_id = content_block.get("tool_use_id")
-                            if tool_use_id in existing_tool_use_ids:
-                                continue
-                            existing_tool_use_ids.add(tool_use_id)
-                        merged_messages[-1]["content"].append(content_block)
-                else:
-                    merged_messages.append(message)
-            return merged_messages
+    def _build_tools(self) -> list[dict]:
+        """Translate function schemas to Anthropic tool definitions.
 
-        messages = merge_messages(messages)
-        messages = self._strip_thinking_from_prior_turns(messages)
-
-        # Need to map field "parameters" to "input_schema"
+        Maps "parameters" to "input_schema" and guarantees a description.
+        """
         tools = []
         for s in self.chat.functions_schema:
             tool_def = {
                 "name": s["name"],
-                "description": s["description"],
+                "description": s["description"] or "No description provided",
                 "input_schema": s["parameters"],
             }
             if s.get("defer_loading"):
                 tool_def["defer_loading"] = True
             tools.append(tool_def)
-        # Add description to the function is their description is empty
-        for tool in tools:
-            if not tool["description"]:
-                tool["description"] = "No description provided"
+        return tools
 
-        # === Add cache_controls ===
-        # Anthropic's prompt caching uses up to 4 breakpoints per request.
-        # We use all 4: system[-1], tools[-1], messages[-3], messages[-1].
-        #
-        # Why messages[-3]?  Each tool-loop iteration appends exactly 2
-        # messages (1 assistant + 1 tool_result).  So messages[-3] in the
-        # current call corresponds to messages[-1] from the *previous* call,
-        # whose prefix was already cached.  By keeping a breakpoint there,
-        # Anthropic can serve that prefix from cache_read instead of
-        # re-caching the entire message history on every iteration.
+    def _build_system_blocks(self) -> list[dict]:
+        """Assemble the system prompt blocks (instruction, context, tools).
+
+        cache_control goes on the LAST system block so the entire system
+        section is cached as a unit.  Anthropic uses cumulative hashes —
+        placing cache_control on system[0] while system[1] varies
+        invalidates every downstream block.
+        """
+        blocks = []
+        for text in (
+            self.chat.instruction,
+            self.chat.context,
+            self.chat.initial_tools_states,
+            self.chat.tool_search_categories_hint,
+        ):
+            if text:
+                blocks.append({"type": "text", "text": text})
+        if blocks:
+            blocks[-1]["cache_control"] = {"type": "ephemeral"}
+        return blocks
+
+    @staticmethod
+    def _apply_cache_control(messages: list[dict], tools: list[dict]) -> None:
+        """Place cache_control breakpoints on messages and tools (in place).
+
+        Anthropic's prompt caching uses up to 4 breakpoints per request.
+        We use all 4: system[-1] (see _build_system_blocks), tools[-1],
+        messages[-3], messages[-1].
+
+        Why messages[-3]?  Each tool-loop iteration appends exactly 2
+        messages (1 assistant + 1 tool_result).  So messages[-3] in the
+        current call corresponds to messages[-1] from the *previous* call,
+        whose prefix was already cached.  By keeping a breakpoint there,
+        Anthropic can serve that prefix from cache_read instead of
+        re-caching the entire message history on every iteration.
+        """
 
         def _set_cache_control(msg_index):
             """Add cache_control to the last content block of messages[msg_index]."""
@@ -309,43 +310,30 @@ class AnthropicProvider(BaseProvider):
             # re-caching the entire prefix (cache_creation).
             if len(messages) >= 3:
                 _set_cache_control(-3)
+
         # Tools: Add cache_control to the last tool function.
         # Tools with defer_loading=true cannot carry cache_control, so
         # walk backward to the last eligible tool.
-        if tools:
-            for tool in reversed(tools):
-                if not tool.get("defer_loading"):
-                    tool["cache_control"] = {"type": "ephemeral"}
-                    break
+        for tool in reversed(tools):
+            if not tool.get("defer_loading"):
+                tool["cache_control"] = {"type": "ephemeral"}
+                break
 
-        # System: add cache_control to the LAST system block so the entire
-        # system section (instruction + tool states) is cached as a unit.
-        # Anthropic uses cumulative hashes — placing cache_control on
-        # system[0] while system[1] varies invalidates every downstream block.
-        system_messages = []
-        if system is not None:
-            system_messages.append({"type": "text", "text": system})
+    def _prepare_request_params(self, **kwargs):
+        """Prepare messages, tools, and kwargs for Anthropic API request."""
+        messages = self.prepare_messages(
+            transform_function=message_to_anthropic_dict,
+            transform_list_function=add_empty_function_result,
+        )
+        messages = self._merge_same_role_messages(messages)
+        messages = self._strip_thinking_from_prior_turns(messages)
 
-        if self.chat.context:
-            system_messages.append({"type": "text", "text": self.chat.context})
+        tools = self._build_tools()
+        self._apply_cache_control(messages, tools)
 
-        if self.chat.initial_tools_states:
-            system_messages.append(
-                {"type": "text", "text": self.chat.initial_tools_states}
-            )
-
-        if hasattr(self.chat, "tool_search_categories_hint") and self.chat.tool_search_categories_hint:
-            system_messages.append(
-                {"type": "text", "text": self.chat.tool_search_categories_hint}
-            )
-
-        if system_messages:
-            system_messages[-1]["cache_control"] = {"type": "ephemeral"}
-
-        # === End of cache_control ===
-
-        if system_messages:
-            kwargs["system"] = system_messages
+        system_blocks = self._build_system_blocks()
+        if system_blocks:
+            kwargs["system"] = system_blocks
 
         if self.chat.use_tools_only and "tool_choice" not in kwargs:
             kwargs["tool_choice"] = {"type": "any"}

--- a/src/agentlys/providers/openai.py
+++ b/src/agentlys/providers/openai.py
@@ -93,6 +93,15 @@ def from_openai_object(
     return Message(role=role, content=content, id=id, usage=usage)
 
 
+def build_system_messages(chat: AgentlysBase) -> list[Message]:
+    """System prompt as role="system" Messages (instruction, context, tool states)."""
+    return [
+        Message(role="system", content=text)
+        for text in (chat.instruction, chat.context, chat.initial_tools_states)
+        if text
+    ]
+
+
 def parts_to_openai_dict(part: MessagePart) -> dict:
     if part.type == "text":
         return {
@@ -172,11 +181,21 @@ def return_image_as_user_message(messages: list[Message]) -> list[Message]:
     """
     Adaptation because OpenAI doesn't support image in function call.
     We return the image as a user message.
+
+    Builds new Message objects instead of mutating: the input list holds the
+    same references as chat.messages, and this runs on every request.
     """
-    for i in range(len(messages)):
-        if messages[i].role == "function" and messages[i].image is not None:
-            messages[i].role = "user"
-    return messages
+    result = []
+    for message in messages:
+        if message.role == "function" and message.image is not None:
+            message = Message(
+                role="user",
+                name=message.name,
+                id=message.id,
+                parts=message.parts,
+            )
+        result.append(message)
+    return result
 
 
 def split_function_results(messages: list[Message]) -> list[Message]:
@@ -230,28 +249,7 @@ class OpenAIProvider(BaseProvider):
             ),
         )
 
-        system_messages = []
-        if self.chat.instruction:
-            system_messages.append(
-                Message(
-                    role="system",
-                    content=self.chat.instruction,
-                )
-            )
-        if self.chat.context:
-            system_messages.append(
-                Message(
-                    role="system",
-                    content=self.chat.context,
-                )
-            )
-        if self.chat.initial_tools_states:
-            system_messages.append(
-                Message(
-                    role="system",
-                    content=self.chat.initial_tools_states,
-                )
-            )
+        system_messages = build_system_messages(self.chat)
         messages = [self.message_transform(sm) for sm in system_messages] + messages
 
         if self.chat.use_tools_only and "tool_choice" not in kwargs:

--- a/src/agentlys/providers/openai_function_legacy.py
+++ b/src/agentlys/providers/openai_function_legacy.py
@@ -2,9 +2,13 @@ import json
 import typing
 
 from agentlys.base import AgentlysBase
-from agentlys.model import Message, MessagePart
+from agentlys.model import Message
 from agentlys.providers.base_provider import BaseProvider
-from agentlys.providers.openai import create_openai_client
+from agentlys.providers.openai import (
+    build_system_messages,
+    create_openai_client,
+    parts_to_openai_dict,
+)
 from agentlys.providers.utils import FunctionCallParsingError
 
 
@@ -26,45 +30,6 @@ def from_openai_object(
             raise FunctionCallParsingError(id, function_call)
 
     return Message(role=role, content=content, function_call=function_call_dict, id=id)
-
-
-def parts_to_openai_dict(part: MessagePart) -> dict:
-    if part.type == "text":
-        return {
-            "type": "text",
-            "text": part.content,
-        }
-    elif part.type == "image":
-        return {
-            "type": "image_url",
-            "image_url": {
-                "url": f"data:{part.image.format};base64,{part.image.to_base64()}"
-            },
-        }
-    elif part.type == "function_call":
-        return {
-            "name": part.function_call["name"],
-            "arguments": json.dumps(part.function_call["arguments"]),
-        }
-    elif part.type == "function_result":
-        return {
-            "type": "text",
-            "text": part.content,
-        }
-    elif part.type == "function_result_image":
-        return {
-            "type": "image_url",
-            "image_url": {
-                "url": f"data:{part.image.format};base64,{part.image.to_base64()}"
-            },
-        }
-    elif part.type == "compaction":
-        return {
-            "type": "text",
-            "text": f"[Previous conversation summary]\n{part.content}",
-        }
-
-    raise ValueError(f"Unknown part type: {part.type}")
 
 
 def message_to_openai_dict(message: Message) -> dict:
@@ -115,30 +80,8 @@ class OpenAIProviderFunctionLegacy(BaseProvider):
 
     async def fetch_async(self, **kwargs) -> Message:
         messages = self.prepare_messages(transform_function=message_to_openai_dict)
-        # Add instruction as the first message
-
-        system_messages = []
-        if self.chat.instruction:
-            system_messages.append(
-                Message(
-                    role="system",
-                    content=self.chat.instruction,
-                )
-            )
-        if self.chat.context:
-            system_messages.append(
-                Message(
-                    role="system",
-                    content=self.chat.context,
-                )
-            )
-        if self.chat.initial_tools_states:
-            system_messages.append(
-                Message(
-                    role="system",
-                    content=self.chat.initial_tools_states,
-                )
-            )
+        # Add the system prompt as the first messages
+        system_messages = build_system_messages(self.chat)
         messages = [message_to_openai_dict(sm) for sm in system_messages] + messages
 
         if self.chat.functions_schema:

--- a/src/agentlys/providers/openai_function_shim.py
+++ b/src/agentlys/providers/openai_function_shim.py
@@ -4,6 +4,7 @@ that don't support them yet in the API (ie. o1).
 """
 
 import json
+import logging
 import typing
 
 from agentlys.model import Message
@@ -32,6 +33,11 @@ def parse_function_call_from_text(text: str):
             # Attempt to parse JSON in the curly braces
             arguments = json.loads(match.group(2))
         except json.JSONDecodeError:
+            logging.warning(
+                "Could not parse arguments of text function call %r; "
+                "falling back to empty arguments",
+                function_name,
+            )
             arguments = {}
         return function_name, arguments
     return None, None
@@ -73,22 +79,15 @@ def message_to_openai_dict(message: Message) -> dict:
 
 
 class OpenAIProviderFunctionShim(OpenAIProvider):
-    async def fetch_async(self):
+    async def fetch_async(self, **kwargs):
         """
         Calls the OpenAI ChatCompletion endpoint using ONLY text-based instructions for function usage.
         """
 
         messages = self.prepare_messages(transform_function=message_to_openai_dict)
-        # Add instruction as the first message
-        if self.chat.instruction:
-            instruction_message = Message(
-                role="user",
-                content=self.chat.instruction,
-            )
-            messages = [message_to_openai_dict(instruction_message)] + messages
 
-        # Inject function schema into the system message, if we haven't already
-        # or just append it to an existing system message. Example:
+        # Build one leading instruction message; it always embeds
+        # chat.instruction, plus the function schemas when there are any.
         if self.chat.functions_schema:
             function_schemas_text = json.dumps(self.chat.functions_schema, indent=2)
             augmented_instruction = (
@@ -124,6 +123,7 @@ class OpenAIProviderFunctionShim(OpenAIProvider):
         res = await self.client.chat.completions.create(
             model=self.model,
             messages=messages,
+            **kwargs,
         )
         # OpenAI returns a structure. We'll parse out the text content
         message = res.choices[0].message

--- a/src/agentlys/tool_search.py
+++ b/src/agentlys/tool_search.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
+from functools import lru_cache
 from typing import TYPE_CHECKING, Callable, Optional
 
 if TYPE_CHECKING:
@@ -39,12 +41,18 @@ _STOP_WORDS = frozenset({
 })
 
 
-def _tokenize(text: str) -> set[str]:
-    """Split text into lowercase tokens, filtering stop words."""
-    import re
+_TOKEN_RE = re.compile(r"[^a-z0-9]+")
 
-    tokens = set(re.split(r"[^a-z0-9]+", text.lower())) - {""}
-    return tokens - _STOP_WORDS
+
+@lru_cache(maxsize=4096)
+def _tokenize(text: str) -> frozenset[str]:
+    """Split text into lowercase tokens, filtering stop words.
+
+    Cached because the catalog side of the search re-tokenizes the same
+    tool names/descriptions on every call.
+    """
+    tokens = set(_TOKEN_RE.split(text.lower())) - {""}
+    return frozenset(tokens - _STOP_WORDS)
 
 
 async def _default_search(

--- a/src/agentlys/utils.py
+++ b/src/agentlys/utils.py
@@ -45,7 +45,9 @@ def limit_data_size(
             if len(result_data) == 0:
                 avg_chars_per_field = (character_limit - total_char_count) // len(row)
                 if avg_chars_per_field < 1:
-                    return "Error: Too many fields to display data within the character limit."
+                    raise ValueError(
+                        "Too many fields to display data within the character limit."
+                    )
                 limited_row = limit_row_chars(row, avg_chars_per_field)
                 result_data.append(limited_row)
             break
@@ -63,7 +65,10 @@ def csv_dumps(data: list[dict], character_limit: typing.Optional[int] = None) ->
         return "[]"
 
     if character_limit:
-        limited_data = limit_data_size(data, character_limit=character_limit)
+        try:
+            limited_data = limit_data_size(data, character_limit=character_limit)
+        except ValueError as e:
+            return f"Error: {e}"
     else:
         limited_data = data
 
@@ -73,7 +78,7 @@ def csv_dumps(data: list[dict], character_limit: typing.Optional[int] = None) ->
         writer.writeheader()
         writer.writerows(limited_data)
         output = output.getvalue().strip()
-        output.replace("\r\n", "\n").replace("\r", "\n")
+        output = output.replace("\r\n", "\n").replace("\r", "\n")
 
     csv_content = f"```csv\n{output}\n```"
 
@@ -108,17 +113,19 @@ def parse_function(text: str) -> dict:
     # Extracting the arguments
     arguments = {}
     for keyword in parsed.keywords:
-        if isinstance(keyword.value, ast.Str):
-            value = keyword.value.s
-            arguments[keyword.arg] = value
-        elif isinstance(keyword.value, ast.List):
-            arguments[keyword.arg] = [el.s for el in keyword.value.elts]
-        elif isinstance(keyword.value, ast.Dict):
-            dict_values = {}
-            for k, v in zip(keyword.value.keys, keyword.value.values):
-                if isinstance(v, ast.Str):
-                    dict_values[k.s] = v.s
-            arguments[keyword.arg] = dict_values
+        value = keyword.value
+        if isinstance(value, ast.Constant):
+            arguments[keyword.arg] = value.value
+        elif isinstance(value, ast.List):
+            arguments[keyword.arg] = [
+                el.value for el in value.elts if isinstance(el, ast.Constant)
+            ]
+        elif isinstance(value, ast.Dict):
+            arguments[keyword.arg] = {
+                k.value: v.value
+                for k, v in zip(value.keys, value.values)
+                if isinstance(k, ast.Constant) and isinstance(v, ast.Constant)
+            }
 
     if not arguments:
         raise ValueError("The function call does not contain any arguments.")
@@ -275,11 +282,14 @@ def inspect_schema(f):
 
 def get_event_loop_or_create():
     try:
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        pass
+    try:
         return asyncio.get_event_loop()
-    except RuntimeError as e:
-        if str(e).startswith("There is no current event loop in thread"):
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            return loop
-        else:
-            raise
+    except RuntimeError:
+        # No current event loop in this thread (get_event_loop raises on
+        # non-main threads, and on every thread from Python 3.14 on)
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        return loop

--- a/tests/test_add_tool.py
+++ b/tests/test_add_tool.py
@@ -38,6 +38,19 @@ def test_add_tool():
     assert f"DummyTool-{tool_id}__class_method" in agent.functions
 
 
+def test_remove_tool():
+    agent = Agentlys()
+    tool_id = agent.add_tool(DummyTool)
+    prefix = f"DummyTool-{tool_id}__"
+    assert any(name.startswith(prefix) for name in agent.functions)
+
+    agent.remove_tool(tool_id)
+
+    assert tool_id not in agent.tools
+    assert not any(f["name"].startswith(prefix) for f in agent.functions_schema)
+    assert not any(name.startswith(prefix) for name in agent.functions)
+
+
 def test_add_tool_with_custom_id():
     agent = Agentlys()
     custom_id = "custom_tool_id"

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -55,5 +55,41 @@ class TestAgentlys(unittest.TestCase):
         self.assertEqual(responses[1].content, "Final response")
 
 
+class TestFormatCallbackMessage(unittest.TestCase):
+    def test_list_of_numbers_is_formatted_as_text(self):
+        agent = Agentlys()
+        message = agent._format_callback_message(
+            function_name="fn",
+            function_call_id="call_1",
+            content=[1, 2, 3],
+            image=None,
+        )
+        self.assertEqual(message.parts[0].content, "1\n2\n3")
+        self.assertEqual(agent.tools, {})
+
+    def test_scalar_is_formatted_as_text(self):
+        agent = Agentlys()
+        message = agent._format_callback_message(
+            function_name="fn",
+            function_call_id="call_1",
+            content=42,
+            image=None,
+        )
+        self.assertEqual(message.parts[0].content, "42")
+        self.assertEqual(agent.tools, {})
+
+
+class TestMcpServersConstructor(unittest.TestCase):
+    def test_constructor_rejects_mcp_servers(self):
+        # add_mcp_server is async; registering from __init__ silently did
+        # nothing, so passing servers here must fail loudly instead.
+        with self.assertRaisesRegex(ValueError, "add_mcp_server"):
+            Agentlys(mcp_servers=[object()])
+
+    def test_constructor_accepts_none(self):
+        agent = Agentlys(mcp_servers=None)
+        self.assertEqual(agent.messages, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,49 @@
+from PIL import Image as PILImage
+
+from agentlys.model import Image, Message, MessagePart
+
+
+def test_content_setter_targets_text_part():
+    """Setting content must write to the text part, not blindly to parts[0]."""
+    message = Message(
+        role="assistant",
+        parts=[
+            MessagePart(type="thinking", thinking="reasoning"),
+            MessagePart(type="text", content="hello"),
+        ],
+    )
+    message.content = "world"
+    assert message.content == "world"
+    assert message.parts[0].thinking == "reasoning"
+    assert message.parts[0].content is None
+
+
+def test_image_to_base64_is_cached():
+    pil = PILImage.new("RGB", (4, 4))
+    pil.format = "PNG"
+    img = Image(pil)
+
+    save_calls = 0
+    original_save = pil.save
+
+    def counting_save(*args, **kwargs):
+        nonlocal save_calls
+        save_calls += 1
+        return original_save(*args, **kwargs)
+
+    pil.save = counting_save
+    first = img.to_base64()
+    second = img.to_base64()
+    assert first == second
+    assert save_calls == 1
+
+
+def test_image_resize_invalidates_base64_cache():
+    pil = PILImage.new("RGB", (4, 4), color="red")
+    pil.format = "PNG"
+    img = Image(pil)
+
+    before = img.to_base64()
+    img.resize((2, 2))
+    after = img.to_base64()
+    assert before != after

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -496,3 +496,26 @@ def test_compaction_part_serializes_as_text():
     assert result["type"] == "text"
     assert "[Previous conversation summary]" in result["text"]
     assert "Talked about the weather" in result["text"]
+
+
+def test_return_image_as_user_message_does_not_mutate_history():
+    """The OpenAI image workaround must not rewrite roles in the shared history."""
+    from PIL import Image as PILImage
+
+    from agentlys.providers.openai import return_image_as_user_message
+
+    original = Message(
+        role="function",
+        name="screenshot",
+        parts=[
+            MessagePart(
+                type="function_result_image",
+                content="ok",
+                image=PILImage.new("RGB", (2, 2)),
+                function_call_id="call_1",
+            )
+        ],
+    )
+    transformed = return_image_as_user_message([original])
+    assert transformed[0].role == "user"
+    assert original.role == "function"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ import unittest
 from pydantic import BaseModel
 
 from agentlys.model import Message
-from agentlys.utils import inspect_schema, limit_data_size, parse_function
+from agentlys.utils import csv_dumps, inspect_schema, limit_data_size, parse_function
 
 
 class TestLimitDataSizeUpdated(unittest.TestCase):
@@ -43,6 +43,18 @@ class TestLimitDataSizeUpdated(unittest.TestCase):
         result = limit_data_size(self.test_data_3, character_limit=80)
         expected = [{"name": "Alice", "age": "25", "city": "New York"}]
         self.assertEqual(result, expected)
+
+
+class TestCsvDumps(unittest.TestCase):
+    def test_normalizes_line_endings(self):
+        output = csv_dumps([{"a": "1", "b": "2"}])
+        self.assertNotIn("\r", output)
+
+    def test_too_many_fields_returns_error_string(self):
+        row = {f"col{i}": "x" for i in range(40)}
+        output = csv_dumps([row], character_limit=20)
+        self.assertIsInstance(output, str)
+        self.assertIn("character limit", output)
 
 
 plot_widget = """
@@ -147,6 +159,14 @@ class TestParseFunction(unittest.TestCase):
             },
         }
         self.assertEqual(result, expected)
+
+    def test_numeric_argument(self):
+        text = """
+        > FUNCTION(name="a", count=5, ratio=0.5)
+        """
+        result = parse_function(text)
+        self.assertEqual(result["arguments"]["count"], 5)
+        self.assertEqual(result["arguments"]["ratio"], 0.5)
 
     def test_parse_array(self):
         text = """


### PR DESCRIPTION
## Summary

Full-library review (perf / clean code) applied as three commits: `fix:`, `perf:`, `refactor:`. Every behavioral fix was written test-first (red → green); 12 new tests, 252 passing.

### Bug fixes (`fix:`)
- **`remove_tool` removed nothing**: it compared the bare `tool_id` against names registered as `ClassName-id__method`. Now filters by prefix, so removed tools actually leave the schema and function registry.
- **`return_image_as_user_message` corrupted history**: it mutated `Message` objects shared with `chat.messages`, permanently flipping stored roles from `function` to `user` on every OpenAI request. Now builds new `Message` objects.
- **`Message.content` setter wrote to the wrong part** when `parts[0]` wasn't the text part (common with extended thinking: thinking block first). Now targets the actual text part.
- **List results dispatch**: the `isinstance(item, object)` catch-all shadowed the numeric branch, so a tool returning `[1, 2, 3]` registered each number as a tool via `add_tool`.
- **`mcp_servers=` constructor arg was a silent no-op** (`add_mcp_server` is async; the coroutines were never awaited). Now raises a clear `ValueError` pointing to `await agent.add_mcp_server(...)`. Also removes the mutable `[]` default.
- **`csv_dumps`**: CRLF normalization was a discarded-`str.replace` no-op; `limit_data_size`'s error path returned a string violating its `list` contract and crashing `csv.DictWriter` downstream.
- **`parse_function`**: `ast.Str` → `ast.Constant` (removed in Python 3.14); numeric arguments are no longer silently dropped.
- **o1 shim**: instruction was sent twice per request; `fetch_async` now accepts `**kwargs` per the base signature; malformed JSON in text function calls is logged instead of swallowed.
- **`Image.resize` lost the PIL format**, breaking any later serialization of a resized image.

### Performance (`perf:` + parts of `fix:`)
- `Image.to_base64` memoized (invalidated on resize): providers re-serialize the whole history each turn, so an N-turn loop with K images re-encoded all K images N times.
- `from_response` signature check cached per function instead of `inspect.signature` on every tool invocation.
- `tool_search`: precompiled regex + `lru_cache`d tokenization (catalog was re-tokenized on every search).
- `initial_tools_states`: O(1) prefix-set lookup instead of O(tools × schemas).

### Cleanup (`refactor:`)
- Deleted dead code: `_call_function_and_build_message` (never called), unreachable `startswith("tool-")` branch, stale `__version__ = "0.4.1"` in `chat.py`.
- Compaction guard unified in `_compaction_allowed()`, shared by `ask_async` and `ask_stream_async`.
- `AnthropicProvider._prepare_request_params` (~170 lines) split into `_merge_same_role_messages` / `_build_tools` / `_build_system_blocks` / `_apply_cache_control`.
- Legacy OpenAI provider now imports the shared `parts_to_openai_dict` and `build_system_messages` instead of duplicating them.
- MCP result truncation deduplicated; `get_event_loop_or_create` no longer string-matches the English asyncio error message.

## Wire-format safety

The cassette tests compare request bodies byte-for-byte via a custom diff matcher and all pass — the Anthropic/OpenAI wire format is unchanged by the refactors.

## Test plan
- [x] `uv run pytest tests/` — 252 passed (12 new tests, written red-first)
- [x] `uv run ruff check src tests` — clean
- [x] No new deprecation warnings (ast.Str warnings gone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)