### PR TITLE
fix(providers): drop orphaned tool_result blocks before the request

### DIFF
--- a/src/agentlys/providers/anthropic.py
+++ b/src/agentlys/providers/anthropic.py
@@ -4,7 +4,10 @@ import anthropic
 from agentlys.base import AgentlysBase
 from agentlys.model import Message, MessagePart
 from agentlys.providers.base_provider import BaseProvider
-from agentlys.providers.utils import add_empty_function_result
+from agentlys.providers.utils import (
+    add_empty_function_result,
+    drop_orphaned_function_results,
+)
 
 
 def part_to_anthropic_dict(part: MessagePart) -> dict:
@@ -323,7 +326,9 @@ class AnthropicProvider(BaseProvider):
         """Prepare messages, tools, and kwargs for Anthropic API request."""
         messages = self.prepare_messages(
             transform_function=message_to_anthropic_dict,
-            transform_list_function=add_empty_function_result,
+            transform_list_function=lambda x: add_empty_function_result(
+                drop_orphaned_function_results(x)
+            ),
         )
         messages = self._merge_same_role_messages(messages)
         messages = self._strip_thinking_from_prior_turns(messages)

--- a/src/agentlys/providers/openai.py
+++ b/src/agentlys/providers/openai.py
@@ -5,7 +5,11 @@ import typing
 from agentlys.base import AgentlysBase
 from agentlys.model import Message, MessagePart
 from agentlys.providers.base_provider import BaseProvider
-from agentlys.providers.utils import FunctionCallParsingError, add_empty_function_result
+from agentlys.providers.utils import (
+    FunctionCallParsingError,
+    add_empty_function_result,
+    drop_orphaned_function_results,
+)
 
 OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1"
 
@@ -245,7 +249,9 @@ class OpenAIProvider(BaseProvider):
         messages = self.prepare_messages(
             transform_function=self.message_transform,
             transform_list_function=lambda x: split_function_results(
-                add_empty_function_result(return_image_as_user_message(x))
+                add_empty_function_result(
+                    return_image_as_user_message(drop_orphaned_function_results(x))
+                )
             ),
         )
 

--- a/src/agentlys/providers/utils.py
+++ b/src/agentlys/providers/utils.py
@@ -1,8 +1,11 @@
+import logging
 import os
 from typing import Type, Union
 
 from agentlys.model import Message, MessagePart
 from agentlys.providers.base_provider import APIProvider, BaseProvider
+
+logger = logging.getLogger(__name__)
 
 
 class FunctionCallParsingError(Exception):
@@ -128,3 +131,64 @@ def add_empty_function_result(messages: list[Message]) -> list[Message]:
                 ),
             )
     return messages
+
+
+def drop_orphaned_function_results(messages: list[Message]) -> list[Message]:
+    """Remove ``function_result`` parts whose ``function_call_id`` matches no
+    ``function_call`` in the history — the mirror of
+    :func:`add_empty_function_result`.
+
+    That helper guards the forward direction (a call with no result); this
+    guards the reverse (a result with no call). Both OpenAI and Anthropic reject
+    a tool result whose id has no matching tool call ("unexpected tool_use_id
+    found in tool_result blocks", HTTP 400), which permanently blocks a
+    conversation whose persisted history was left with a dangling result: a
+    stream interrupted mid-tool-use, or an assistant tool_use turn deleted /
+    regenerated after the result row was saved.
+
+    Builds new ``Message`` objects instead of mutating: the input list holds the
+    same references as ``chat.messages`` and this runs on every request. A
+    message emptied by stripping only-orphaned results is dropped.
+    """
+    valid_call_ids = {
+        part.function_call_id
+        for message in messages
+        for part in message.parts
+        if part.type == "function_call" and part.function_call_id is not None
+    }
+
+    result: list[Message] = []
+    for message in messages:
+        kept_parts = []
+        dropped_parts = []
+        for part in message.parts:
+            is_result = part.type in ("function_result", "function_result_image")
+            if is_result and part.function_call_id not in valid_call_ids:
+                dropped_parts.append(part)
+            else:
+                kept_parts.append(part)
+
+        if not dropped_parts:
+            result.append(message)
+            continue
+
+        for part in dropped_parts:
+            logger.warning(
+                "Dropping orphaned %s (function_call_id=%s) with no matching "
+                "function_call in conversation history",
+                part.type,
+                part.function_call_id,
+            )
+
+        # A message emptied by removing only-orphaned results is dropped; an
+        # already-empty message is left untouched by the branch above.
+        if kept_parts:
+            result.append(
+                Message(
+                    role=message.role,
+                    name=message.name,
+                    id=message.id,
+                    parts=kept_parts,
+                )
+            )
+    return result

--- a/tests/test_anthropic.py
+++ b/tests/test_anthropic.py
@@ -10,7 +10,20 @@ class TestAnthropic(unittest.TestCase):
 
     def test_transform_conversation_anthropic(self):
         agent = Agentlys(instruction="Test instruction", provider=APIProvider.ANTHROPIC)
+        # A tool result must be preceded by its tool_use — an orphaned result
+        # (no matching call) is stripped before the request, so the history has
+        # to carry the assistant tool_use for the merge to be exercised.
         agent.messages = [
+            Message(
+                role="assistant",
+                parts=[
+                    MessagePart(
+                        type="function_call",
+                        function_call={"name": "SUBMIT", "arguments": {}},
+                        function_call_id="example_16",
+                    )
+                ],
+            ),
             Message(
                 role="function",
                 name="SUBMIT",
@@ -22,6 +35,17 @@ class TestAnthropic(unittest.TestCase):
 
         expected_output = [
             {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "example_16",
+                        "name": "SUBMIT",
+                        "input": {},
+                    }
+                ],
+            },
+            {
                 "role": "user",
                 "content": [
                     {"type": "tool_result", "tool_use_id": "example_16", "content": ""},
@@ -31,7 +55,7 @@ class TestAnthropic(unittest.TestCase):
                         "cache_control": {"type": "ephemeral"},
                     },
                 ],
-            }
+            },
         ]
         agent.provider.client = self.mock_anthropic_client
 
@@ -255,7 +279,11 @@ class TestCacheControlPlacement(unittest.TestCase):
                 self.content = content
 
             def to_dict(self):
-                return {"role": self.role, "content": self.content, "usage": {"input_tokens": 100, "output_tokens": 50}}
+                return {
+                    "role": self.role,
+                    "content": self.content,
+                    "usage": {"input_tokens": 100, "output_tokens": 50},
+                }
 
         mock_create = AsyncMock(
             return_value=FakeAnthropicMessage(role="assistant", content="test")
@@ -341,7 +369,9 @@ class TestContextInSystemPrompt(unittest.TestCase):
         if isinstance(first_msg_content, str):
             user_texts = [first_msg_content]
         else:
-            user_texts = [b.get("text", "") for b in first_msg_content if isinstance(b, dict)]
+            user_texts = [
+                b.get("text", "") for b in first_msg_content if isinstance(b, dict)
+            ]
         self.assertFalse(
             any(context in t for t in user_texts),
             "Context should NOT be in user messages",
@@ -565,9 +595,7 @@ class TestCacheBreakpointOnPreviousIteration(unittest.TestCase):
                     ),
                 ],
             ),
-            Message(
-                role="function", content="Alice,Bob", function_call_id="old_1"
-            ),
+            Message(role="function", content="Alice,Bob", function_call_id="old_1"),
             Message(role="assistant", content="Here are the users."),
         ]
         question = Message(role="user", content="Count orders per user")
@@ -589,7 +617,9 @@ class TestCacheBreakpointOnPreviousIteration(unittest.TestCase):
                         type="function_call",
                         function_call={
                             "name": "run_query",
-                            "arguments": {"sql": "SELECT user_id, COUNT(*) FROM orders GROUP BY 1"},
+                            "arguments": {
+                                "sql": "SELECT user_id, COUNT(*) FROM orders GROUP BY 1"
+                            },
                         },
                         function_call_id="call_1",
                     ),
@@ -663,7 +693,10 @@ class TestCacheBreakpointOnPreviousIteration(unittest.TestCase):
                     MessagePart(type="text", content="Let me check."),
                     MessagePart(
                         type="function_call",
-                        function_call={"name": "run_query", "arguments": {"sql": "SELECT 1"}},
+                        function_call={
+                            "name": "run_query",
+                            "arguments": {"sql": "SELECT 1"},
+                        },
                         function_call_id="call_1",
                     ),
                 ],
@@ -701,8 +734,12 @@ class TestCacheBreakpointOnPreviousIteration(unittest.TestCase):
         results = Message(
             role="function",
             parts=[
-                MessagePart(type="function_result", content="R1", function_call_id="p1"),
-                MessagePart(type="function_result", content="R2", function_call_id="p2"),
+                MessagePart(
+                    type="function_result", content="R1", function_call_id="p1"
+                ),
+                MessagePart(
+                    type="function_result", content="R2", function_call_id="p2"
+                ),
             ],
         )
 
@@ -776,10 +813,13 @@ class TestEmptyTextBlockFiltering(unittest.TestCase):
         """Empty text parts should be skipped when serializing to API format."""
         from agentlys.providers.anthropic import message_to_anthropic_dict
 
-        msg = Message(role="assistant", parts=[
-            MessagePart(type="text", content=""),
-            MessagePart(type="text", content="hello"),
-        ])
+        msg = Message(
+            role="assistant",
+            parts=[
+                MessagePart(type="text", content=""),
+                MessagePart(type="text", content="hello"),
+            ],
+        )
         result = message_to_anthropic_dict(msg)
         text_blocks = [b for b in result["content"] if b.get("type") == "text"]
         self.assertEqual(len(text_blocks), 1)
@@ -789,10 +829,13 @@ class TestEmptyTextBlockFiltering(unittest.TestCase):
         """Whitespace-only text parts should be skipped when serializing."""
         from agentlys.providers.anthropic import message_to_anthropic_dict
 
-        msg = Message(role="assistant", parts=[
-            MessagePart(type="text", content="  \n "),
-            MessagePart(type="text", content="valid"),
-        ])
+        msg = Message(
+            role="assistant",
+            parts=[
+                MessagePart(type="text", content="  \n "),
+                MessagePart(type="text", content="valid"),
+            ],
+        )
         result = message_to_anthropic_dict(msg)
         text_blocks = [b for b in result["content"] if b.get("type") == "text"]
         self.assertEqual(len(text_blocks), 1)

--- a/tests/test_orphaned_tool_results.py
+++ b/tests/test_orphaned_tool_results.py
@@ -1,0 +1,180 @@
+"""Reverse-direction guard for the tool_use / tool_result contract.
+
+``add_empty_function_result`` guards the *forward* direction (a ``function_call``
+with no ``function_result``). ``drop_orphaned_function_results`` guards the
+*reverse*: a ``function_result`` whose ``function_call_id`` matches no
+``function_call`` in the history. Both OpenAI and Anthropic reject such an
+orphaned result ("unexpected tool_use_id found in tool_result blocks", HTTP
+400), which permanently blocks a conversation whose persisted history was left
+with a dangling result — a stream interrupted mid-tool-use, or an assistant
+tool_use turn deleted / regenerated after the result row was saved.
+"""
+
+import pytest
+
+from agentlys import Agentlys
+from agentlys.model import Message, MessagePart
+from agentlys.providers.utils import drop_orphaned_function_results
+
+
+def _assistant_call(call_id):
+    return Message(
+        role="assistant",
+        parts=[
+            MessagePart(
+                type="function_call",
+                function_call={"name": "get_weather", "arguments": {}},
+                function_call_id=call_id,
+            )
+        ],
+    )
+
+
+def _function_result(call_id, content="ok"):
+    return Message(
+        role="function",
+        parts=[
+            MessagePart(
+                type="function_result", content=content, function_call_id=call_id
+            )
+        ],
+    )
+
+
+def _result_ids(messages):
+    return {
+        part.function_call_id
+        for message in messages
+        for part in message.parts
+        if part.type in ("function_result", "function_result_image")
+    }
+
+
+def test_orphaned_result_message_is_dropped():
+    """A ``function`` message whose only result references a missing call is
+    removed entirely, leaving the valid pair and surrounding turns intact."""
+    messages = [
+        Message(role="user", content="hello"),
+        _assistant_call("toolu_valid"),
+        _function_result("toolu_valid"),
+        _function_result("toolu_orphan"),  # no matching function_call
+    ]
+
+    sanitized = drop_orphaned_function_results(messages)
+
+    assert _result_ids(sanitized) == {"toolu_valid"}
+    assert [m.role for m in sanitized] == ["user", "assistant", "function"]
+
+
+def test_orphaned_part_stripped_but_sibling_result_kept():
+    """A parallel-tool ``function`` message keeps its valid result and drops
+    only the orphaned part; the message itself survives."""
+    messages = [
+        _assistant_call("toolu_valid"),
+        Message(
+            role="function",
+            parts=[
+                MessagePart(
+                    type="function_result", content="ok", function_call_id="toolu_valid"
+                ),
+                MessagePart(
+                    type="function_result",
+                    content="orphan",
+                    function_call_id="toolu_orphan",
+                ),
+            ],
+        ),
+    ]
+
+    sanitized = drop_orphaned_function_results(messages)
+
+    assert _result_ids(sanitized) == {"toolu_valid"}
+    assert len(sanitized) == 2
+    assert len(sanitized[1].parts) == 1
+
+
+def test_valid_history_passes_through_by_reference():
+    """A well-formed history is returned untouched, same object references (no
+    needless copies on the hot path)."""
+    messages = [
+        Message(role="user", content="hi"),
+        _assistant_call("toolu_a"),
+        _function_result("toolu_a"),
+    ]
+
+    sanitized = drop_orphaned_function_results(messages)
+
+    assert sanitized == messages
+    assert _result_ids(sanitized) == {"toolu_a"}
+
+
+def test_does_not_mutate_shared_history():
+    """Must build new ``Message`` objects rather than strip parts in place — the
+    input list holds the same references as ``chat.messages`` and this runs on
+    every request."""
+    orphan_message = Message(
+        role="function",
+        parts=[
+            MessagePart(
+                type="function_result", content="ok", function_call_id="toolu_valid"
+            ),
+            MessagePart(
+                type="function_result",
+                content="orphan",
+                function_call_id="toolu_orphan",
+            ),
+        ],
+    )
+    messages = [_assistant_call("toolu_valid"), orphan_message]
+
+    drop_orphaned_function_results(messages)
+
+    # The original message still carries both parts — nothing mutated in place.
+    assert len(orphan_message.parts) == 2
+
+
+def _orphan_history():
+    return [
+        Message(role="user", content="hi"),
+        _assistant_call("toolu_valid"),
+        _function_result("toolu_valid"),
+        _function_result("toolu_orphan"),
+    ]
+
+
+def test_anthropic_pipeline_drops_orphaned_tool_result():
+    """End to end: an orphaned result never reaches the Anthropic request."""
+    agent = Agentlys(
+        provider="anthropic", model="claude-3-7-sonnet-latest", api_key="test"
+    )
+    agent.messages = _orphan_history()
+
+    messages, _tools, _kwargs = agent.provider._prepare_request_params()
+
+    tool_result_ids = {
+        block.get("tool_use_id")
+        for message in messages
+        for block in (
+            message["content"] if isinstance(message["content"], list) else []
+        )
+        if isinstance(block, dict) and block.get("type") == "tool_result"
+    }
+    assert "toolu_orphan" not in tool_result_ids
+    assert "toolu_valid" in tool_result_ids
+
+
+def test_openai_pipeline_drops_orphaned_tool_result(monkeypatch):
+    """End to end: an orphaned result never reaches the OpenAI request."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    agent = Agentlys(provider="openai", model="gpt-4o")
+    agent.messages = _orphan_history()
+
+    messages, _tools, _kwargs = agent.provider._prepare_request_params()
+
+    tool_call_ids = {m.get("tool_call_id") for m in messages if m.get("role") == "tool"}
+    assert "toolu_orphan" not in tool_call_ids
+    assert "toolu_valid" in tool_call_ids
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

A persisted conversation can carry a `function_result` whose `function_call_id` matches **no** `function_call` in the loaded history — the reverse of the gap [`add_empty_function_result`](https://github.com/myriade-ai/agentlys/blob/master/src/agentlys/providers/utils.py) already guards (a call with no result). This orphan arises upstream when a stream is interrupted mid-tool-use, or an assistant `tool_use` turn is deleted/regenerated after the result row was saved.

Both **OpenAI** and **Anthropic** reject the request:

```
400 invalid_request_error: unexpected tool_use_id found in tool_result blocks
```

Because the orphan is reconstructed identically on every reload, this **permanently blocks every send/regenerate** on that conversation — an upgrade alone can't heal it.

Observed in production (Myriade `jules`, 2.112.0): 9 back-to-back `Background agent/regenerate error` failures on a single conversation, all the same block `messages.38.content.1` / `toolu_vrtx_…`.

## Fix

Add `drop_orphaned_function_results()` right next to `add_empty_function_result()` and compose it into **both** providers' `transform_list_function` pipeline (Anthropic + OpenAI-compatible). It collects every `function_call_id` produced by a `function_call` part, then strips any `function_result` / `function_result_image` part whose id isn't in that set (logging a warning), dropping a message left with only orphaned results.

- **Symmetric** with the existing forward-direction guard — same `list[Message]` stage, same file.
- **Non-mutating**: builds new `Message` objects (the input list aliases `chat.messages` and runs on every request), matching `return_image_as_user_message` / `split_function_results`.
- **Order-preserving**; a valid history passes through by reference (no copies on the hot path).

## Tests

- `tests/test_orphaned_tool_results.py` (new): pure-function cases (orphan message dropped, orphaned part stripped while a valid sibling in a parallel-tool message is kept, valid history untouched, no in-place mutation) + end-to-end assertions that the orphan never reaches the prepared Anthropic **or** OpenAI request.
- `tests/test_anthropic.py::test_transform_conversation_anthropic`: its fixture previously encoded an *orphaned* `tool_result` (the exact bug) and asserted it was forwarded — updated to a valid `tool_use → tool_result → user` history so it still exercises the function→user merge + cache_control.

`258 passed` locally; `ruff check` clean.

## Rollout note

The Myriade app also ships a repair-on-read guard (myriade-private #882) to heal already-corrupted conversations immediately. Once this lands and releases, that app-side helper becomes belt-and-suspenders and Myriade can rely on the library invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)