### PR TITLE
fix: replace instead of duplicating schemas when re-registering a tool or function name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v2
+        with:
+          # Keep in sync with the ruff version locked in uv.lock — "latest"
+          # breaks every open PR whenever a ruff release changes the rule set.
+          version: "0.15.17"
 
   test:
     runs-on: ubuntu-latest

--- a/src/agentlys/chat.py
+++ b/src/agentlys/chat.py
@@ -445,13 +445,31 @@ class Agentlys(AgentlysBase):
         ):
             function_schema["defer_loading"] = True
 
-        self.functions_schema.append(function_schema)
-        self.functions[function_schema["name"]] = function
+        # Re-registering a name replaces the previous function. Dispatch
+        # (self.functions) is last-wins, so the schema list must follow:
+        # a duplicate name in functions_schema reaches the provider payload
+        # and Anthropic/OpenAI reject the whole request ("tool names must
+        # be unique").
+        name = function_schema["name"]
+        existing_index = next(
+            (i for i, s in enumerate(self.functions_schema) if s["name"] == name),
+            None,
+        )
+        if existing_index is not None:
+            self.functions_schema[existing_index] = function_schema
+        else:
+            self.functions_schema.append(function_schema)
+        self.functions[name] = function
 
     def add_tool(
         self, tool: typing.Union[type, object], tool_id: typing.Optional[str] = None
     ) -> str:
-        """Add a tool class or instance to the chat instance and return the tool id"""
+        """Add a tool class or instance to the chat instance and return the tool id.
+
+        Re-registering an existing tool_id replaces the previous tool: its
+        registrations are removed first, so methods that only existed on the
+        old tool (e.g. when the class differs) don't linger.
+        """
         if isinstance(tool, type):
             # If a class is provided, instantiate it
             tool = tool()
@@ -459,6 +477,8 @@ class Agentlys(AgentlysBase):
         if tool_id is None:
             tool_id = str(id(tool))
 
+        if tool_id in self.tools:
+            self.remove_tool(tool_id)
         self.tools[tool_id] = tool
 
         class_name = tool.__class__.__name__

--- a/tests/test_add_tool.py
+++ b/tests/test_add_tool.py
@@ -74,3 +74,54 @@ def test_add_tool_instance():
     assert f"DummyTool-{tool_id}__method1" in function_names
     assert f"DummyTool-{tool_id}__method2" in function_names
     assert f"DummyTool-{tool_id}___private_method" not in function_names
+
+
+class OtherTool:
+    def other_method(self):
+        pass
+
+
+def test_re_add_tool_same_id_replaces_without_duplicate_schemas():
+    agent = Agentlys()
+    first = DummyTool()
+    second = DummyTool()
+    agent.add_tool(first, tool_id="editor")
+    agent.add_tool(second, tool_id="editor")
+
+    names = [f["name"] for f in agent.functions_schema]
+    assert len(names) == len(set(names))
+    assert agent.tools["editor"] is second
+    # Dispatch points at the replacing instance's bound method
+    assert agent.functions["DummyTool-editor__method1"].__self__ is second
+
+
+def test_re_add_tool_different_class_drops_old_methods():
+    agent = Agentlys()
+    agent.add_tool(DummyTool(), tool_id="editor")
+    agent.add_tool(OtherTool(), tool_id="editor")
+
+    names = [f["name"] for f in agent.functions_schema]
+    assert "OtherTool-editor__other_method" in names
+    assert not any(name.startswith("DummyTool-editor__") for name in names)
+    assert not any(name.startswith("DummyTool-editor__") for name in agent.functions)
+
+
+def test_add_function_same_name_replaces_in_place():
+    agent = Agentlys()
+
+    def tool_a():
+        return "a"
+
+    def tool_b():
+        return "b"
+
+    agent.add_function(tool_a, {"name": "shared", "description": "a", "parameters": {}})
+    agent.add_function(
+        lambda: None, {"name": "other", "description": "", "parameters": {}}
+    )
+    agent.add_function(tool_b, {"name": "shared", "description": "b", "parameters": {}})
+
+    names = [f["name"] for f in agent.functions_schema]
+    assert names == ["shared", "other"]
+    assert agent.functions_schema[0]["description"] == "b"
+    assert agent.functions["shared"] is tool_b


### PR DESCRIPTION
## Problem

`Chat.add_function` appends every schema to `functions_schema` while the `functions` dispatch dict is last-wins. Re-registering a name — the main case being `add_tool(new_impl, tool_id=existing_id)` to swap a tool implementation — therefore leaves **two identical-named tool definitions** in the provider payload. Anthropic/OpenAI reject such payloads outright (`400 'tools: Tool names must be unique.'`), so an intentional tool replacement turns into a hard failure of every subsequent model request in the conversation.

This is the root cause of myriade-private DEV-1382 (see myriade-ai/myriade-private#927): `GithubTool._add_workspace_tools` re-registers `dbt_editor` under the same tool_id to swap the lazy all-repos DBT editor for a repo-scoped one after `initialize_workspace()` — the comment there even says "must be replaced" — but `add_tool` appended instead of replacing, and the next model call 400'd.

## Fix

- `add_function`: when the name is already registered, replace the existing schema entry **in place** (preserving list order, and thus cache-control placement on `tools[-1]`) instead of appending a duplicate.
- `add_tool`: when the tool_id is already registered, remove the previous tool's registrations first (via `remove_tool`), so methods that only existed on the old tool — including a different class under the same id — don't linger.

Every registration path funnels through `add_function` (`add_tool`, `add_mcp_server`, `add_sub_agent`, the tool-search registration), so with this change `functions_schema` names are unique by construction and the schema list always matches the dispatch dict.

## Tests

- Re-adding the same tool_id: no duplicate schema names; dispatch points at the replacing instance.
- Re-adding a different class under the same tool_id: the old class's methods are dropped.
- `add_function` with an existing name: replaced in place, order preserved.
- Full suite: 271 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)